### PR TITLE
[fbeV1] add resetIMU methods and test estimation with root/head imu

### DIFF
--- a/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/estimators/fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/estimators/fbe-analogsens.xml
@@ -58,11 +58,11 @@
 
         <!-- biped foot contact classifier parameters -->
         <param name="initial_primary_foot">right</param>
-        <param name="schmitt_stable_contact_make_time">1.0</param>
-        <param name="schmitt_stable_contact_break_time">1.0</param>
+        <param name="schmitt_stable_contact_make_time">0.01</param>
+        <param name="schmitt_stable_contact_break_time">0.01</param>
         <param name="left_schmitt_contact_make_force_threshold">130.0</param>
         <param name="left_schmitt_contact_break_force_threshold">25.0</param>
-        <param name="right_schmitt_contact_make_force_threshold">150.0</param>
+        <param name="right_schmitt_contact_make_force_threshold">130.0</param>
         <param name="right_schmitt_contact_break_force_threshold">25.0</param>
 
         <!-- whole body dynamics for getting contact forces -->

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -394,6 +394,8 @@ namespace yarp {
          */
         bool updateBaseVelocityWithIMU();
 
+        bool setRobotStateWithZeroBaseVelocity();
+
         /**
          * @brief parent method for other publish methods
          */
@@ -484,10 +486,15 @@ namespace yarp {
         virtual bool setPrimaryFoot(const std::string& primary_foot);
         virtual std::string getRefFrameForWorld();
         virtual Pose6D getRefPose6DForWorld();
+        virtual bool resetIMU();
         virtual bool resetLeggedOdometry();
         virtual bool resetLeggedOdometryWithRefFrame(const std::string& ref_frame,
                                                     const double x, const double y, const double z,
                                                     const double roll, const double pitch, const double yaw);
+        virtual bool resetEstimator();
+        virtual bool resetEstimatorWithRefFrame(const std::string& ref_frame,
+                                            const double x, const double y, const double z,
+                                            const double roll, const double pitch, const double yaw);
         virtual bool startFloatingBaseFilter();
         virtual bool useJointVelocityLPF(const bool flag);
         virtual bool setJointVelocityLPFCutoffFrequency(const double freq);

--- a/devices/baseEstimatorV1/scope/base_scope.xml
+++ b/devices/baseEstimatorV1/scope/base_scope.xml
@@ -1,12 +1,5 @@
-<!--
-  Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT)
-  All rights reserved.
- 
-  This software may be modified and distributed under the terms of the
-  GNU Lesser General Public License v2.1 or any later version.
- -->
 <?xml version="1.0" encoding="UTF-8" ?>
-<portscope rows="3" columns="2" carrier="mcast">
+<portscope rows="3" columns="2" carrier="udp">
         <plot gridx="0"
               gridy="0"
               hspan="1"
@@ -31,12 +24,12 @@
                    type="lines"
                    size="3" />
 
-           <graph remote="/walking-coordinator/floating_base:o"
+<!--           <graph remote="/walking-coordinator/floating_base:o"
                    index="0"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
         </plot>
 
@@ -63,12 +56,12 @@
                    title="FBE y"
                    type="lines"
                    size="3" />
-<graph remote="/walking-coordinator/floating_base:o"
+<!--<graph remote="/walking-coordinator/floating_base:o"
                    index="1"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
          </plot>
 
@@ -97,12 +90,12 @@
                    size="3" />
 
 
-          <graph remote="/walking-coordinator/floating_base:o"
+<!--          <graph remote="/walking-coordinator/floating_base:o"
                    index="2"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
          </plot>
 
@@ -133,12 +126,12 @@
                    size="3" />
 
 
-<graph remote="/walking-coordinator/floating_base:o"
+<!--<graph remote="/walking-coordinator/floating_base:o"
                    index="3"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
          </plot>
 
@@ -167,12 +160,12 @@
                    size="3" />
 
 
-<graph remote="/walking-coordinator/floating_base:o"
+<!--<graph remote="/walking-coordinator/floating_base:o"
                    index="4"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
          </plot>
 
@@ -200,12 +193,12 @@
                    type="lines"
                    size="3" />
 
-           <graph remote="/walking-coordinator/floating_base:o"
+<!--           <graph remote="/walking-coordinator/floating_base:o"
                    index="5"
                    color="Blue"
                    title="walking x"
                    type="lines"
-                   size="3" />
+                   size="3" /> -->
 
          </plot>
 </portscope>

--- a/devices/baseEstimatorV1/thrifts/floatingBaseEstimationRPC.thrift
+++ b/devices/baseEstimatorV1/thrifts/floatingBaseEstimationRPC.thrift
@@ -5,7 +5,7 @@
  * This software may be modified and distributed under the terms of the
  * GNU Lesser General Public License v2.1 or any later version.
  */
- 
+
 struct Pose6D
 {
     1: double x; 2: double y; 3: double z;
@@ -23,9 +23,14 @@ service floatingBaseEstimationRPC
 
     bool setPrimaryFoot(1: string primary_foot);
 
+    bool resetIMU();
     bool resetLeggedOdometry();
     bool resetLeggedOdometryWithRefFrame(1: string ref_frame, 2: double x, 3: double y, 4: double z,
                                        5: double roll, 6: double pitch, 7: double yaw);
+    bool resetEstimator();
+    bool resetEstimatorWithRefFrame(1: string ref_frame, 2: double x, 3: double y, 4: double z,
+                                 5: double roll, 6: double pitch, 7: double yaw);
+
     string getRefFrameForWorld();
     Pose6D getRefPose6DForWorld();
     bool useJointVelocityLPF(1: bool flag);


### PR DESCRIPTION
This PR adds resetIMU methods to the estimator.

The proper functioning of fusion between legged odometry and head/root link IMU was also tested.