### PR TITLE
[fbeV1] Publishing COM computed from estimated base state

### DIFF
--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -394,7 +394,19 @@ namespace yarp {
          */
         bool updateBaseVelocityWithIMU();
 
+        /**
+         * @brief sets robot state for kindyncomputations object using estimated base pose,
+         *  kinematic measurements and zero base velocity
+         * @return true/false success/failure
+         */
         bool setRobotStateWithZeroBaseVelocity();
+
+        /**
+         * @brief get robot's center of mass position using estimated base pose and
+         *  kinematic measurements
+         * @return true/false success/failure
+         */
+        bool getCOMPositionAndVelocity(iDynTree::Position& com_position, iDynTree::Vector3& com_vel);
 
         /**
          * @brief parent method for other publish methods
@@ -425,6 +437,12 @@ namespace yarp {
          *        x y z roll pitch yaw vx vy vz omegax omegay omegaz
          */
         void publishFloatingBasePoseVelocity();
+
+        /**
+         * @brief publish center of mass position and velocity through YARP port
+         *       x y z vz vy vz
+         */
+        void publishCOMEstimate();
 
         /**
          * @brief publish feet contact state through YARP port
@@ -588,6 +606,7 @@ namespace yarp {
         yarp::os::BufferedPort<yarp::os::Bottle> m_imu_attitude_observer_estimated_state_port; ///< port to publish rotation as RPY and IMU gyro bias
         yarp::os::BufferedPort<yarp::os::Bottle> m_imu_attitude_qekf_estimated_state_port; ///< port to publish rotation as RPY and IMU gyro bias
         yarp::os::Port m_estimator_rpc_port; ///< RPC port for service calls
+        yarp::os::BufferedPort<yarp::os::Bottle> m_com_port; ///< port to publish estimated com position and velocity as x y z vx vy vz
 
         iDynTree::RPY m_imu_attitude_estimate_as_rpy;
 
@@ -614,6 +633,8 @@ namespace yarp {
         std::string m_left_sole{"l_sole"};
         iDynTree::Rotation m_l_sole_R_l_ft_sensor, m_r_sole_R_r_ft_sensor;
         iDynTree::KinDynComputations m_kin_dyn_comp;
+        iDynTree::Position m_com_position;
+        iDynTree::Vector3 m_com_velocity;
 
         std::string m_left_foot_cartesian_wrench_port_name, m_right_foot_cartesian_wrench_port_name;
         yarp::os::BufferedPort<yarp::sig::Vector> m_left_foot_cartesian_wrench_wbd_port, m_right_foot_cartesian_wrench_wbd_port;

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -38,7 +38,7 @@
 #include <string>
 #include <WalkingLogger.hpp>
 #include <thrifts/floatingBaseEstimationRPC.h>
-
+#include <mutex>
 #include <iCub/ctrl/filters.h>
 
 inline double deg2rad(const double angleInDeg)
@@ -521,7 +521,7 @@ namespace yarp {
         bool m_verbose{true}; ///< verbose outputs
         std::string m_port_prefix{"/base-estimator"};
 
-        yarp::os::Mutex m_device_mutex; ///< mutex to avoid resource clash
+        std::mutex m_device_mutex; ///< mutex to avoid resource clash
 
         // status flags
         bool m_device_initialized_correctly{false};

--- a/devices/baseEstimatorV1/src/baseEstimatorV1.cpp
+++ b/devices/baseEstimatorV1/src/baseEstimatorV1.cpp
@@ -60,7 +60,7 @@ yarp::dev::baseEstimatorV1::baseEstimatorV1(): PeriodicThread(0.01, yarp::os::Sh
 
 bool yarp::dev::baseEstimatorV1::open(yarp::os::Searchable& config)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     if (!configureWholeBodyDynamics(config))
     {
         yError() << "floatingBaseEstimatorV1: " <<  "Could not connect to wholebodydynamics";
@@ -764,7 +764,7 @@ void yarp::dev::baseEstimatorV1::publish()
 
 void yarp::dev::baseEstimatorV1::run()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
 
     if(m_state != FilterFSM::RUNNING)
         return;
@@ -904,7 +904,7 @@ void yarp::dev::baseEstimatorV1::closeDevice()
 
 bool yarp::dev::baseEstimatorV1::close()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     closeDevice();
 
     return true;
@@ -919,21 +919,21 @@ yarp::dev::baseEstimatorV1::~baseEstimatorV1()
 
 bool yarp::dev::baseEstimatorV1::setMahonyKp(const double kp)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_imu_attitude_observer->setGainkp(kp);
     return true;
 }
 
 bool yarp::dev::baseEstimatorV1::setMahonyKi(const double ki)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_imu_attitude_observer->setGainki(ki);
     return true;
 }
 
 bool yarp::dev::baseEstimatorV1::setMahonyTimeStep(const double timestep)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_imu_attitude_observer->setTimeStepInSeconds(timestep);
     return true;
 }
@@ -941,7 +941,7 @@ bool yarp::dev::baseEstimatorV1::setMahonyTimeStep(const double timestep)
 bool yarp::dev::baseEstimatorV1::setContactSchmittThreshold(const double l_fz_break, const double l_fz_make,
                                                                         const double r_fz_break, const double r_fz_make)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_biped_foot_contact_classifier->m_leftFootContactClassifier->m_contactSchmitt->setLowValueThreshold(l_fz_break);
     m_biped_foot_contact_classifier->m_leftFootContactClassifier->m_contactSchmitt->setHighValueThreshold(l_fz_make);
     m_biped_foot_contact_classifier->m_rightFootContactClassifier->m_contactSchmitt->setLowValueThreshold(r_fz_break);
@@ -955,7 +955,7 @@ bool yarp::dev::baseEstimatorV1::setContactSchmittThreshold(const double l_fz_br
 
 std::string yarp::dev::baseEstimatorV1::getEstimationJointsList()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     std::stringstream ss;
     for (int i = 0; i < m_estimation_joint_names.size(); i++)
     {
@@ -975,7 +975,7 @@ std::string yarp::dev::baseEstimatorV1::getEstimationJointsList()
 
 bool yarp::dev::baseEstimatorV1::setPrimaryFoot(const std::string& primary_foot)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     if (primary_foot == "right")
     {
         m_current_fixed_frame = "r_foot";
@@ -1002,13 +1002,13 @@ bool yarp::dev::baseEstimatorV1::setPrimaryFoot(const std::string& primary_foot)
 
 std::string yarp::dev::baseEstimatorV1::getRefFrameForWorld()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     return m_initial_reference_frame_for_world;
 }
 
 Pose6D yarp::dev::baseEstimatorV1::getRefPose6DForWorld()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     Pose6D ref_pose_world;
     ref_pose_world.x = m_initial_reference_frame_H_world.getPosition()(0);
     ref_pose_world.y = m_initial_reference_frame_H_world.getPosition()(1);
@@ -1021,7 +1021,7 @@ Pose6D yarp::dev::baseEstimatorV1::getRefPose6DForWorld()
 
 bool yarp::dev::baseEstimatorV1::resetLeggedOdometry()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_legged_odometry->updateKinematics(m_joint_positions);
     bool ok = m_legged_odometry->init(m_initial_fixed_frame, m_initial_reference_frame_for_world, m_initial_reference_frame_H_world);
     updateLeggedOdometry();
@@ -1030,7 +1030,7 @@ bool yarp::dev::baseEstimatorV1::resetLeggedOdometry()
 
 bool yarp::dev::baseEstimatorV1::resetIMU()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     bool ok{false};
     if (m_attitude_estimator_type == "qekf")
     {
@@ -1057,7 +1057,7 @@ bool yarp::dev::baseEstimatorV1::resetEstimator()
 
 bool yarp::dev::baseEstimatorV1::startFloatingBaseFilter()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_state = FilterFSM::RUNNING;
     return true;
 }
@@ -1066,7 +1066,7 @@ bool yarp::dev::baseEstimatorV1::resetLeggedOdometryWithRefFrame(const std::stri
                                                                       const double x, const double y, const double z,
                                                                       const double roll, const double pitch, const double yaw)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_initial_reference_frame_for_world = ref_frame;
     iDynTree::Position w_p_b(x, y ,z);
     iDynTree::Rotation w_R_b{iDynTree::Rotation::RPY(roll, pitch, yaw)};

--- a/devices/baseEstimatorV1/src/configureEstimator.cpp
+++ b/devices/baseEstimatorV1/src/configureEstimator.cpp
@@ -538,6 +538,13 @@ bool yarp::dev::baseEstimatorV1::openComms()
         return false;
     }
 
+    ok = m_com_port.open(m_port_prefix + "/center_of_mass/state:o");
+    if (!ok)
+    {
+        yError() << "floatingBaseEstimatorV1: " << "could not open port " << m_port_prefix + "/center_of_mass/state:o";
+        return false;
+    }
+
     return true;
 }
 

--- a/devices/baseEstimatorV1/src/fbeRobotInterface.cpp
+++ b/devices/baseEstimatorV1/src/fbeRobotInterface.cpp
@@ -30,7 +30,7 @@ bool  yarp::dev::baseEstimatorV1::sensorReadDryRun(bool verbose, bool (yarp::dev
 
 bool yarp::dev::baseEstimatorV1::attachAll(const yarp::dev::PolyDriverList& p)
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     if (!attachAllControlBoards(p))
     {
         yError() << "baseEstimatorV1: " <<  "Could not attach the control boards";
@@ -566,7 +566,7 @@ bool yarp::dev::baseEstimatorV1::loadTransformBroadcaster()
 
 bool yarp::dev::baseEstimatorV1::detachAll()
 {
-    yarp::os::LockGuard guard(m_device_mutex);
+    std::lock_guard<std::mutex> guard(m_device_mutex);
     m_device_initialized_correctly = false;
     if (isRunning())
     {


### PR DESCRIPTION
This PR does the following,
- computes COM state from estimated base pose, base velocity and kinematic measurements
The COM state is available on the port
`/` estimator-prefix `/center_of_mass/state:o` in serialziation `x  y z vx vy vz` 
- fixes deprecation of yarp::os::Mutex and yarp::os::LockGuard by using std::mutex and std::lock_guard

cc @S-Dafarra
