### PR TITLE
Avoid publishing during initialization

### DIFF
--- a/devices/baseEstimatorV1/src/baseEstimatorV1.cpp
+++ b/devices/baseEstimatorV1/src/baseEstimatorV1.cpp
@@ -793,7 +793,6 @@ void yarp::dev::baseEstimatorV1::run()
                 ok = initializeIMUAttitudeQEKF();
             }
             ok = alignIMUFrames();
-            publish();
             if (m_dump_data)
             {
                 initializeLogger();


### PR DESCRIPTION
Publishing during the initialization step was streaming zero values for the published quantities which might undesirable when compared to not having data.

cc @S-Dafarra