### PR TITLE
Add support for compensating temperature in Force/Torque sensors readings and for specify user offline offset 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added 'startWithZeroFTSensorOffsets' option when passed starts the WBD device with zero offsets for FT sensors, bypassing the offset calibration. (See [!72](https://github.com/robotology/whole-body-estimators/pull/72)).
+- Added support for compensating temperature in Force/Torque sensors readings and for specify user offline offset. (See [!45](https://github.com/robotology/whole-body-estimators/pull/45))
 
 ## [0.2.1] - 2020-04-08
 ### Fixed

--- a/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.cpp
+++ b/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.cpp
@@ -68,15 +68,12 @@ const double& SixAxisForceTorqueMeasureProcessor::tempOffset() const
 
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench& input) const
 {
-    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)-toEigen(m_offset);
-    iDynTree::Wrench ret;
-    fromEigen(ret,retEig);
-    return ret;
+    return filt(input, 0.0);
 }
 
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench & input, const double & temperature) const
 {
-    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)-toEigen(m_offset)+toEigen(m_temperatureCoefficients)*(temperature-m_tempOffset);    
+    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)-toEigen(m_offset)+toEigen(m_temperatureCoefficients)*(temperature-m_tempOffset);
     iDynTree::Wrench ret;
     fromEigen(ret,retEig);
 
@@ -86,12 +83,7 @@ iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench
 
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::applySecondaryCalibrationMatrix(const iDynTree::Wrench& input) const
 {
-    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input);
-
-    iDynTree::Wrench ret;
-    fromEigen(ret,retEig);
-
-    return ret;
+    return applySecondaryCalibrationMatrix( input, 0.0);
 }
 
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::applySecondaryCalibrationMatrix(const iDynTree::Wrench& input, const double & temperature) const
@@ -105,5 +97,3 @@ iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::applySecondaryCalibrationMa
 }
 
 }
-
-

--- a/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.cpp
+++ b/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.cpp
@@ -1,6 +1,7 @@
 #include "SixAxisForceTorqueMeasureHelpers.h"
 #include <iDynTree/Core/EigenHelpers.h>
 
+
 namespace wholeBodyDynamics
 {
 
@@ -9,6 +10,9 @@ SixAxisForceTorqueMeasureProcessor::SixAxisForceTorqueMeasureProcessor()
     // Initialize the affice function to be the identity
     toEigen(m_secondaryCalibrationMatrix).setIdentity();
     m_offset.zero();
+    toEigen(m_temperatureCoefficients).setZero();
+    m_tempOffset=0.0;
+    m_estimated_offset.zero();
 }
 
 iDynTree::Matrix6x6& SixAxisForceTorqueMeasureProcessor::secondaryCalibrationMatrix()
@@ -16,10 +20,20 @@ iDynTree::Matrix6x6& SixAxisForceTorqueMeasureProcessor::secondaryCalibrationMat
     return m_secondaryCalibrationMatrix;
 }
 
+iDynTree::Vector6& SixAxisForceTorqueMeasureProcessor::temperatureCoefficients()
+{
+    return m_temperatureCoefficients;
+}
+
 
 const iDynTree::Matrix6x6& SixAxisForceTorqueMeasureProcessor::secondaryCalibrationMatrix() const
 {
     return m_secondaryCalibrationMatrix;
+}
+
+const iDynTree::Vector6& SixAxisForceTorqueMeasureProcessor::temperatureCoefficients() const
+{
+    return m_temperatureCoefficients;
 }
 
 iDynTree::Wrench& SixAxisForceTorqueMeasureProcessor::offset()
@@ -32,12 +46,40 @@ const iDynTree::Wrench& SixAxisForceTorqueMeasureProcessor::offset() const
     return m_offset;
 }
 
+iDynTree::Wrench& SixAxisForceTorqueMeasureProcessor::estimatedOffset()
+{
+    return m_estimated_offset;
+}
+
+const iDynTree::Wrench& SixAxisForceTorqueMeasureProcessor::estimatedOffset() const
+{
+    return m_estimated_offset;
+}
+
+double& SixAxisForceTorqueMeasureProcessor::tempOffset()
+{
+    return m_tempOffset;
+}
+
+const double& SixAxisForceTorqueMeasureProcessor::tempOffset() const
+{
+    return m_tempOffset;
+}
+
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench& input) const
 {
     Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)-toEigen(m_offset);
-
     iDynTree::Wrench ret;
     fromEigen(ret,retEig);
+    return ret;
+}
+
+iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench & input, const double & temperature) const
+{
+    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)-toEigen(m_offset)+toEigen(m_temperatureCoefficients)*(temperature-m_tempOffset);    
+    iDynTree::Wrench ret;
+    fromEigen(ret,retEig);
+
 
     return ret;
 }
@@ -45,6 +87,16 @@ iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::filt(const iDynTree::Wrench
 iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::applySecondaryCalibrationMatrix(const iDynTree::Wrench& input) const
 {
     Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input);
+
+    iDynTree::Wrench ret;
+    fromEigen(ret,retEig);
+
+    return ret;
+}
+
+iDynTree::Wrench SixAxisForceTorqueMeasureProcessor::applySecondaryCalibrationMatrix(const iDynTree::Wrench& input, const double & temperature) const
+{
+    Eigen::Matrix<double,6,1> retEig = toEigen(m_secondaryCalibrationMatrix)*toEigen(input)+toEigen(m_temperatureCoefficients)*(temperature-m_tempOffset);
 
     iDynTree::Wrench ret;
     fromEigen(ret,retEig);

--- a/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.h
+++ b/devices/wholeBodyDynamics/SixAxisForceTorqueMeasureHelpers.h
@@ -28,7 +28,10 @@ class SixAxisForceTorqueMeasureProcessor
 {
 private:
     iDynTree::Matrix6x6 m_secondaryCalibrationMatrix;
-    iDynTree::Wrench m_offset;
+    iDynTree::Wrench m_offset;    
+    iDynTree::Wrench m_estimated_offset;
+    iDynTree::Vector6 m_temperatureCoefficients;
+    double m_tempOffset;
 
 public:
     /**
@@ -48,6 +51,16 @@ public:
     const iDynTree::Wrench & offset() const;
 
     /**
+     * Accessor to the offline estimated offset.
+     */
+    iDynTree::Wrench & estimatedOffset();
+
+    /**
+     * Const accessor to the offline estimated offset.
+     */
+    const iDynTree::Wrench & estimatedOffset() const;
+
+    /**
      * Accessor to the secondary calibration matrix.
      */
     iDynTree::Matrix6x6 & secondaryCalibrationMatrix();
@@ -58,6 +71,26 @@ public:
     const iDynTree::Matrix6x6 & secondaryCalibrationMatrix() const;
 
     /**
+    * Accessor to the temperature offset.
+    */
+   double & tempOffset();
+
+   /**
+    * Const accessor to the temperature offset.
+    */
+   const double & tempOffset() const;
+
+   /**
+    * Accessor to the temperature Coefficients.
+    */
+   iDynTree::Vector6 & temperatureCoefficients();
+
+   /**
+    * Const accessor to the temperature Coefficients.
+    */
+   const iDynTree::Vector6 & temperatureCoefficients() const;
+
+    /**
      * Process the input F/T.
      *
      * Returns secondaryCalibrationMatrix*input + offset .
@@ -65,9 +98,24 @@ public:
     iDynTree::Wrench filt(const iDynTree::Wrench & input) const;
 
     /**
+     * Process the input F/T.
+     *
+     * Returns secondaryCalibrationMatrix*input + offset + temperatureCoefficients*(temperature-temperatureOffset).
+     */
+    iDynTree::Wrench filt(const iDynTree::Wrench & input, const double & temperature) const;
+
+    /**
      * Process the input F/T by only applyng the calibration matrix.
      */
     iDynTree::Wrench applySecondaryCalibrationMatrix(const iDynTree::Wrench & input) const;
+
+    /**
+     * Process the input F/T by only applyng the calibration matrix and temperature coefficients.
+     */
+    iDynTree::Wrench applySecondaryCalibrationMatrix(const iDynTree::Wrench & input, const double & temperature) const;
+
+
+
 };
 
 }

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -11,7 +11,7 @@
 
 #include <iDynTree/yarp/YARPConversions.h>
 #include <iDynTree/Core/Utils.h>
-
+#include <iDynTree/Core/EigenHelpers.h>
 #include <cassert>
 #include <cmath>
 
@@ -43,6 +43,10 @@ WholeBodyDynamicsDevice::WholeBodyDynamicsDevice(): RateThread(10),
     calibrationBuffers.measurementSumBuffer.resize(0);
     calibrationBuffers.nrOfSamplesToUseForCalibration = 0;
     calibrationBuffers.nrOfSamplesUsedUntilNowForCalibration = 0;
+    // temperature measuremnts vector
+    tempMeasurements.resize(0);
+    ftTempMapping.resize(0);
+    prevFTTempTimeStamp=0;
 
 }
 
@@ -142,46 +146,34 @@ void addVectorOfStringToProperty(yarp::os::Property& prop, std::string key, std:
     return;
 }
 
-bool getUsedDOFsList(os::Searchable& config, std::vector<std::string> & usedDOFs)
+bool getConfigParamsAsList(os::Searchable& config,std::string propertyName , std::vector<std::string> & list)
 {
     yarp::os::Property prop;
     prop.fromString(config.toString().c_str());
-
-    yarp::os::Bottle *propAxesNames=prop.find("axesNames").asList();
-    if(propAxesNames==0)
+    yarp::os::Bottle *propNames=prop.find(propertyName).asList();
+    if(propNames==nullptr)
     {
-       yError() <<"WholeBodyDynamicsDevice: Error parsing parameters: \"axesNames\" should be followed by a list\n";
-       return false;
+        yError() <<"WholeBodyDynamicsDevice: Error parsing parameters: \" "<<propertyName<<" \" should be followed by a list\n";
+        return false;
     }
 
-    usedDOFs.resize(propAxesNames->size());
-    for(int ax=0; ax < propAxesNames->size(); ax++)
+    list.resize(propNames->size());
+    for(auto elem=0u; elem < propNames->size(); elem++)
     {
-        usedDOFs[ax] = propAxesNames->get(ax).asString().c_str();
+        list[elem] = propNames->get(elem).asString().c_str();
     }
 
     return true;
 }
 
+bool getUsedDOFsList(os::Searchable& config, std::vector<std::string> & usedDOFs)
+{
+    return getConfigParamsAsList(config,"axesNames",usedDOFs);
+}
+
 bool getGravityCompensationDOFsList(os::Searchable& config, std::vector<std::string> & gravityCompensationDOFs)
 {
-    yarp::os::Property prop;
-    prop.fromString(config.toString().c_str());
-
-    yarp::os::Bottle *propAxesNames=prop.find("gravityCompensationAxesNames").asList();
-    if(propAxesNames==0)
-    {
-       yError() <<"wholeBodyDynamics : Error parsing parameters: \"gravityCompensationAxesNames\" should be followed by a list\n";
-       return false;
-    }
-
-    gravityCompensationDOFs.resize(propAxesNames->size());
-    for(int ax=0; ax < propAxesNames->size(); ax++)
-    {
-        gravityCompensationDOFs[ax] = propAxesNames->get(ax).asString().c_str();
-    }
-
-    return true;
+    return getConfigParamsAsList(config,"gravityCompensationAxesNames",gravityCompensationDOFs);
 }
 
 
@@ -707,6 +699,54 @@ bool WholeBodyDynamicsDevice::openExternalWrenchesPorts(os::Searchable& config)
     return ok;
 }
 
+bool WholeBodyDynamicsDevice::openMultipleAnalogSensorRemapper(os::Searchable &config)
+{
+    // Pass to the remapper just the relevant parameters (sensorList)
+    yarp::os::Property prop;
+    prop.fromString(config.toString().c_str());
+    yarp::os::Property propMASRemapper;
+    yarp::os::Bottle & propMasNames=prop.findGroup("multipleAnalogSensorsNames");
+    propMASRemapper.put("device","multipleanalogsensorsremapper");
+    bool ok=false;
+    for (auto types=1u;types<propMasNames.size();types++){
+        yarp::os::Bottle * mas_type = propMasNames.get(types).asList();
+        if( mas_type->size() != 2 || mas_type->get(1).asList() == nullptr )
+        {
+            yError() << "wholeBodyDynamics: multipleAnalogSensorsNames group is malformed (" << mas_type->toString() << "). ";
+            return false;
+        }
+        else {
+            ok=true;
+        }
+
+        propMASRemapper.addGroup(mas_type->get(0).asString());
+        yarp::os::Bottle  MASnames;
+        yarp::os::Bottle & MASnamesList= MASnames.addList();
+        for(auto i=0u; i < mas_type->get(1).asList()->size(); i++)
+        {
+            MASnamesList.addString(mas_type->get(1).asList()->get(i).asString());
+        }
+        propMASRemapper.put(mas_type->get(0).asString(),MASnames.get(0));
+
+    }
+    ok = multipleAnalogRemappedDevice.open(propMASRemapper);
+    if( !ok )
+    {
+        return ok;
+    }
+    // View relevant interfaces for the multipleAnalogRemappedDevice
+    ok = ok && multipleAnalogRemappedDevice.view(remappedMASInterfaces.temperatureSensors);
+    ok = ok && multipleAnalogRemappedDevice.view(remappedMASInterfaces.ftMultiSensors);
+    ok = ok && multipleAnalogRemappedDevice.view(remappedMASInterfaces.multwrap);
+    if( !ok )
+    {
+        yError() << "wholeBodyDynamics : openMultipleAnalogSensorRemapper : error while opening the necessary interfaces in multipleAnalogRemappedDevice";
+        return ok;
+    }
+
+   return true;
+}
+
 bool WholeBodyDynamicsDevice::openFilteredFTPorts(os::Searchable& config)
 {
     bool ok = true;
@@ -763,6 +803,10 @@ void WholeBodyDynamicsDevice::resizeBuffers()
     calibrationBuffers.predictedSensorMeasurementsForCalibration.resize(estimator.sensors());
 
     ftProcessors.resize(nrOfFTSensors);
+
+    // Resize temperature sensor inside F/T sensors
+    this->tempMeasurements.resize(nrOfFTSensors,0.0);
+    this->ftTempMapping.resize(nrOfFTSensors,-1);
 
     // Resize filters
     filters.init(nrOfFTSensors,
@@ -1022,6 +1066,130 @@ bool WholeBodyDynamicsDevice::loadSecondaryCalibrationSettingsFromConfig(os::Sea
 
 }
 
+bool WholeBodyDynamicsDevice::loadTemperatureCoefficientsSettingsFromConfig(os::Searchable& config)
+{
+    bool ret;
+    yarp::os::Property propAll;
+    propAll.fromString(config.toString().c_str());
+
+    if( !propAll.check("FT_TEMPERATURE_COEFFICIENTS") )
+    {
+        ret = true;
+    }
+    else
+    {
+        yarp::os::Bottle & propTempCoeff = propAll.findGroup("FT_TEMPERATURE_COEFFICIENTS");
+        for(auto i=1u; i < propTempCoeff.size(); i++ )
+        {
+            yarp::os::Bottle * map_bot = propTempCoeff.get(i).asList();
+            if( map_bot->size() != 2 || map_bot->get(1).asList() == nullptr ||
+                    map_bot->get(1).asList()->size() != 7 )
+            {
+                yError() << "wholeBodyDynamics: FT_TEMPERATURE_COEFFICIENTS group is malformed (" << map_bot->toString() << "). ";
+                return false;
+            }
+
+            std::string iDynTree_sensorName = map_bot->get(0).asString();
+            iDynTree::Vector6 temperatureCoeffs;
+            double tempOffset=0;
+
+            for(auto r=0u; r < 6; r++)
+            {
+                temperatureCoeffs(r) = map_bot->get(1).asList()->get(r).asDouble();
+            }
+            tempOffset= map_bot->get(1).asList()->get(6).asDouble();
+
+            // Linearly search for the specified sensor
+            bool sensorFound = false;
+            for(auto ft=0; ft < estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE); ft++ )
+            {
+
+                if( estimator.sensors().getSensor(iDynTree::SIX_AXIS_FORCE_TORQUE,ft)->getName() == iDynTree_sensorName )
+                {
+                    yDebug() << "wholeBodyDynamics: using temperature coefficients for sensor " << iDynTree_sensorName << " temperatureCoeffs values " << temperatureCoeffs.toString();
+
+                    ftProcessors[ft].temperatureCoefficients() = temperatureCoeffs;
+                    ftProcessors[ft].tempOffset() =tempOffset;
+                    sensorFound = true;
+                    break;
+                }
+            }
+
+            // If a specified sensor was not found, give an error
+            if( !sensorFound )
+            {
+                yError() << "wholeBodyDynamics: temperature coefficients matrix specified for FT sensor " << iDynTree_sensorName
+                         << " but no sensor with that name found in the model";
+                return false;
+            }
+        }
+        ret = true;
+    }
+
+    return ret;
+
+}
+
+bool WholeBodyDynamicsDevice::loadFTSensorOffsetFromConfig(os::Searchable& config)
+{
+    bool ret;
+    yarp::os::Property propAll;
+    propAll.fromString(config.toString().c_str());
+
+    if( !propAll.check("FT_OFFSET") )
+    {
+        ret = true;
+    }
+    else
+    {
+        yarp::os::Bottle & propSecondCalib = propAll.findGroup("FT_OFFSET");
+        for(auto i=1u; i < propSecondCalib.size(); i++ )
+        {
+            yarp::os::Bottle * map_bot = propSecondCalib.get(i).asList();
+            if( map_bot->size() != 2 || map_bot->get(1).asList() == nullptr ||
+                    map_bot->get(1).asList()->size() != 6 )
+            {
+                yError() << "wholeBodyDynamics: FT_OFFSET group is malformed (" << map_bot->toString() << "). ";
+                return false;
+            }
+
+            std::string iDynTree_sensorName = map_bot->get(0).asString();
+            iDynTree::Wrench  ftOffset;
+
+            for(int r=0; r < 6; r++)
+            {
+                ftOffset(r) = map_bot->get(1).asList()->get(r).asDouble();
+            }
+
+
+            // Linearly search for the specified sensor
+            bool sensorFound = false;
+            for(int ft=0; ft < estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE); ft++ )
+            {
+                if( estimator.sensors().getSensor(iDynTree::SIX_AXIS_FORCE_TORQUE,ft)->getName() == iDynTree_sensorName )
+                {
+                    yDebug() << "wholeBodyDynamics: using FT offset"<< ftOffset.toString() <<" for sensor " << iDynTree_sensorName;
+
+                    ftProcessors[ft].estimatedOffset() = ftOffset;
+                    sensorFound = true;
+                }
+            }
+
+            // If a specified sensor was not found, give an error
+            if( !sensorFound )
+            {
+                yError() << "wholeBodyDynamics: FT offset specified for FT sensor " << iDynTree_sensorName
+                         << " but no sensor with that name found in the model";
+                return false;
+            }
+        }
+        ret = true;
+    }
+
+    return ret;
+
+}
+
 
 bool WholeBodyDynamicsDevice::loadGravityCompensationSettingsFromConfig(os::Searchable& config)
 {
@@ -1113,7 +1281,7 @@ bool WholeBodyDynamicsDevice::open(os::Searchable& config)
 
     // Load settings in the class
     ok = this->loadSettingsFromConfig(config);
-   if( !ok ) 
+   if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in loading settings from config.";
         return false;
@@ -1121,51 +1289,67 @@ bool WholeBodyDynamicsDevice::open(os::Searchable& config)
 
     // Create the estimator
     ok = this->openEstimator(config);
-     if( !ok ) 
+     if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening estimator object.";
         return false;
-    } 
+    }
 
     // Open settings related to gravity compensation (we need the estimator to be open)
     ok = this->loadGravityCompensationSettingsFromConfig(config);
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening gravity compensator settings.";
         return false;
-    } 
+    }
 
     // Open settings related to gravity compensation (we need the estimator to be open)
     ok = this->loadSecondaryCalibrationSettingsFromConfig(config);
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in loading secondary calibration matrix settings.";
         return false;
-    } 
+    }
+
+    // Open settings related to gravity compensation (we need the estimator to be open)
+    ok = this->loadTemperatureCoefficientsSettingsFromConfig(config);
+    if( !ok )
+    {
+        yError() << "wholeBodyDynamics: Problem in loading temperature coefficients matrix settings.";
+        return false;
+    }
+
+    // Open settings related to gravity compensation (we need the estimator to be open)
+    ok = this->loadFTSensorOffsetFromConfig(config);
+    if( !ok )
+    {
+        yError() << "wholeBodyDynamics: Problem in loading offline estimated ft offsets settings.";
+        return false;
+    }
 
     // Open rpc port
     ok = this->openRPCPort();
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening rpc port.";
         return false;
-    } 
+    }
 
     // Open settings port
     ok = this->openSettingsPort();
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening settings port.";
         return false;
-    } 
+    }
 
     // Open the controlboard remapper
     ok = this->openRemapperControlBoard(config);
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening controlboard remapper.";
         return false;
-    } 
+    }
 
      // Open the virtualsensor remapper
     ok = this->openRemapperVirtualSensors(config);
@@ -1173,30 +1357,39 @@ bool WholeBodyDynamicsDevice::open(os::Searchable& config)
     {
         yError() << "wholeBodyDynamics: Problem in opening virtual analog sensors remapper.";
         return false;
-    } 
+    }
+
 
     ok = this->openContactFrames(config);
     if( !ok ) 
     {
         yError() << "wholeBodyDynamics: Problem in opening default contact frame settings.";
         return false;
-    } 
+    }
 
     // Open the skin-related ports
     ok = this->openSkinContactListPorts(config);
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening skin-related port.";
         return false;
-    } 
+    }
 
     // Open the ports related to publishing external wrenches
     ok = this->openExternalWrenchesPorts(config);
-    if( !ok ) 
+    if( !ok )
     {
         yError() << "wholeBodyDynamics: Problem in opening external wrenches port.";
         return false;
-    } 
+    }
+
+    // Open the multiple analog sensor remapper
+    ok = this->openMultipleAnalogSensorRemapper(config);
+    if( !ok )
+    {
+        yError() << "wholeBodyDynamics: Problem in opening multiple analog sensor remapper.";
+        return false;
+    }
 
     // Open the ports related to publishing filtered ft wrenches
     if (streamFilteredFT){
@@ -1250,21 +1443,39 @@ bool WholeBodyDynamicsDevice::attachAllVirtualAnalogSensor(const PolyDriverList&
 
 bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
 {
+    yInfo()<<"Starting attach MAS and analog ft";
+    PolyDriverList ftSensorList;
+    PolyDriverList tempSensorList;
+    //std::vector<std::string>     tempDeviceNames;
     std::vector<IAnalogSensor *> ftList;
     std::vector<std::string>     ftDeviceNames;
-    for(size_t devIdx = 0; devIdx < (size_t)p.size(); devIdx++)
+    for(auto devIdx = 0; devIdx <p.size(); devIdx++)
     {
+        ISixAxisForceTorqueSensors * fts = nullptr;
+        ITemperatureSensors *tempS =nullptr;
+        if( p[devIdx]->poly->view(fts) )
+        {
+            ftSensorList.push(const_cast<PolyDriverDescriptor&>(*p[devIdx]));
+            ftDeviceNames.push_back(p[devIdx]->key);
+        }
         // A device is considered an ft if it implements IAnalogSensor and has 6 channels
-        IAnalogSensor * pAnalogSens = 0;
+        IAnalogSensor * pAnalogSens = nullptr;
         if( p[devIdx]->poly->view(pAnalogSens) )
         {
-            if( pAnalogSens->getChannels() == (int)wholeBodyDynamics_nrOfChannelsOfYARPFTSensor )
+            if( pAnalogSens->getChannels() ==static_cast<int>(wholeBodyDynamics_nrOfChannelsOfYARPFTSensor) )
             {
                 ftList.push_back(pAnalogSens);
                 ftDeviceNames.push_back(p[devIdx]->key);
             }
         }
+
+        if( p[devIdx]->poly->view(tempS) )
+        {
+            tempSensorList.push(const_cast<PolyDriverDescriptor&>(*p[devIdx]));
+           // tempDeviceNames.push_back(p[devIdx]->key);
+        }
     }
+    yDebug()<<"wholeBodyDynamicsDevice :: number of ft sensors found in both ft + mas"<<ftDeviceNames.size()<< "where analog are "<<ftList.size()<<" and mas are "<<ftSensorList.size();
 
     if( ftList.size() != estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE) )
     {
@@ -1274,6 +1485,60 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
         return false;
     }
 
+    // Attach the controlBoardList to the controlBoardRemapper
+    bool ok = remappedMASInterfaces.multwrap->attachAll(ftSensorList);
+    ok = ok & remappedMASInterfaces.multwrap->attachAll(tempSensorList);
+
+    if( !ok  )
+    {
+        yError() << " WholeBodyDynamicsDevice::attachAll in attachAll of the remappedMASInterfaces";
+        return false;
+    }
+
+    // Check if the MASremapper and the estimator have a consistent number of ft sensors
+    int tempSensors = 0;
+    tempSensors=static_cast<int>( remappedMASInterfaces.temperatureSensors->getNrOfTemperatureSensors());
+    if( tempSensors > static_cast<int>( estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE)) )
+    {
+        yError() << "wholeBodyDynamics : The multipleAnalogRemappedDevice has more sensors than those in the open estimator ft sensors list";
+        return false;
+    }
+
+    // Temporary code to check name of sensors, assuming the temperature sensor name will be the same as the ft sensor
+    int checkCounter=0;
+    std::string ftName;
+    std::string tempName;
+    int ftMap=-1;
+    //for (auto & sensorName : tempDeviceNames){
+    for (int tSensor=0;tSensor<tempSensors;tSensor++){
+        remappedMASInterfaces.temperatureSensors->getTemperatureSensorName(tSensor,tempName);
+        int individualCheck=0;
+        for (int ft=0;ft<static_cast<int>( estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE)); ft++){
+            ftName=estimator.sensors().getSensor(iDynTree::SIX_AXIS_FORCE_TORQUE,ft)->getName();
+            if (tempName==ftName){
+                individualCheck++;
+                ftMap=ft;
+            }
+        }
+        if (individualCheck!=1){
+            yWarning()<< "wholeBodyDynamics : A temperature sensor name in multipleAnalogRemappedDevice do not match the name of the ft sensors";
+            yDebug()<<"wholeBodyDynamics : Could not find or found multiple times sensor "<<tempName<<" among ft sensor names";
+        }
+        else {
+            checkCounter++;
+            // assuming the name is the same the order withing the mas interfaces might have a different id so we need a mapping
+            ftTempMapping[static_cast<size_t>(ftMap)]=tSensor;
+            yInfo()<< "wholeBodyDynamics: ftTempMapping "<< ftMap << " is ft position in model "<< tSensor <<"="<<ftTempMapping[ftMap] << " sensor name "<< tempName;
+        }
+    }
+    if (checkCounter!=tempSensors){
+        yError("wholeBodyDynamics : Not all temperature sensors have the same name as the ft sensors, expected %d , found %d",tempSensors,checkCounter);
+
+    }
+    //End of temporary temperature check
+
+
+    // Old check performed on ft sensors
     // For now we assume that the name of the F/T sensor device match the sensor name in the URDF
     // In the future we could use a new fancy sensor interface
     ftSensors.resize(ftList.size());
@@ -1422,14 +1687,39 @@ void convertVectorFromDegreesToRadians(iDynTree::VectorDynSize & vector)
 bool WholeBodyDynamicsDevice::readFTSensors(bool verbose)
 {
     bool FTSensorsReadCorrectly = true;
+    bool TempSensorReadCorrectly = true;
+    double timeFTStamp=yarp::os::Time::now();
+    bool readTemperatureSensorThisTime=false;
+    yarp::dev::MAS_status    sensorStatus;
     for(size_t ft=0; ft < estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE); ft++ )
     {
         iDynTree::Wrench bufWrench;
         int ftRetVal = ftSensors[ft]->read(ftMeasurement);
+//TODO: change 0.55 for a variable. 0.55 was related to the fact that temperature sensors are updated once every second
+        if (timeFTStamp-prevFTTempTimeStamp>0.55){
+            if (ftTempMapping[ft]!=-1){
+                sensorStatus=remappedMASInterfaces.temperatureSensors->getTemperatureSensorStatus(ftTempMapping[ft]);
+                std::string nameOfSensor;
+                remappedMASInterfaces.temperatureSensors->getTemperatureSensorName(ftTempMapping[ft],nameOfSensor);
 
+
+                if (sensorStatus==MAS_OK ){
+                    TempSensorReadCorrectly=remappedMASInterfaces.temperatureSensors->getTemperatureSensorMeasure(ftTempMapping[ft],tempMeasurements[ft],timeFTStamp);
+                     remappedMASInterfaces.temperatureSensors->getTemperatureSensorStatus(ftTempMapping[ft]);
+                }
+                else
+                { //should be yError() but lets leave it like this for now
+                    yInfo()<<"wholeBodyDynamics : Temp sensor "<< nameOfSensor << " return status "<< sensorStatus;
+                }
+                readTemperatureSensorThisTime=true;
+            }
+            else {
+                tempMeasurements[ft]=0;
+            }
+        }
         bool ok = (ftRetVal == IAnalogSensor::AS_OK);
 
-        FTSensorsReadCorrectly = FTSensorsReadCorrectly && ok;
+        FTSensorsReadCorrectly = FTSensorsReadCorrectly && ok && TempSensorReadCorrectly;
 
         if( !ok && verbose )
         {
@@ -1440,7 +1730,7 @@ bool WholeBodyDynamicsDevice::readFTSensors(bool verbose)
         bool isNaN = false;
         for (size_t i = 0; i < ftMeasurement.size(); i++)
         {
-            if( std::isnan(ftMeasurement[i]) )
+            if( std::isnan(ftMeasurement[i]) ||  std::isnan(tempMeasurements[ft]))
             {
                 isNaN = true;
                 break;
@@ -1461,7 +1751,9 @@ bool WholeBodyDynamicsDevice::readFTSensors(bool verbose)
             rawSensorsMeasurements.setMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,bufWrench);
         }
     }
-
+    if (readTemperatureSensorThisTime) {
+        prevFTTempTimeStamp=timeFTStamp;
+    }
     return FTSensorsReadCorrectly;
 }
 
@@ -1573,7 +1865,7 @@ void WholeBodyDynamicsDevice::filterSensorsAndRemoveSensorOffsets()
         iDynTree::Wrench rawFTMeasure;
         rawSensorsMeasurements.getMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,rawFTMeasure);
 
-        iDynTree::Wrench rawFTMeasureWithOffsetRemoved  = ftProcessors[ft].filt(rawFTMeasure);
+        iDynTree::Wrench rawFTMeasureWithOffsetRemoved  = ftProcessors[ft].filt(rawFTMeasure,tempMeasurements[ft]);
 
         // Filter the data
         iDynTree::toYarp(rawFTMeasureWithOffsetRemoved,filters.bufferYarp6);
@@ -1727,7 +2019,7 @@ void WholeBodyDynamicsDevice::readContactPoints()
                 //  less than 10 taxels are active then suppose zero moment
                 if( it->getActiveTaxels()<10)
                 {
-                    it->fixMoment();                    
+                    it->fixMoment();
                 }
                 contactsReadFromSkin.insert(contactsReadFromSkin.end(),*it);
                 numberOfContacts++;
@@ -1860,7 +2152,8 @@ void WholeBodyDynamicsDevice::computeCalibration()
                 rawSensorsMeasurements.getMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,measuredRawFT);
 
                 // We apply only the secondary calibration matrix because we are actually computing the offset right now
-                measuredRawFT = ftProcessors[ft].applySecondaryCalibrationMatrix(measuredRawFT);
+                measuredRawFT = ftProcessors[ft].applySecondaryCalibrationMatrix(measuredRawFT,tempMeasurements[ft]);
+
 
                 addToSummer(calibrationBuffers.offsetSumBuffer[ft],measuredRawFT-estimatedFT);
                 addToSummer(calibrationBuffers.measurementSumBuffer[ft],measuredRawFT);
@@ -2158,6 +2451,7 @@ bool WholeBodyDynamicsDevice::detachAll()
 
     this->remappedControlBoardInterfaces.multwrap->detachAll();
     this->remappedVirtualAnalogSensorsInterfaces.multwrap->detachAll();
+    this->remappedMASInterfaces.multwrap->detachAll();
 
     closeFilteredFTPorts();
     closeExternalWrenchesPorts();
@@ -2173,6 +2467,7 @@ bool WholeBodyDynamicsDevice::close()
 {
     this->remappedControlBoard.close();
     this->remappedVirtualAnalogSensors.close();
+    this->multipleAnalogRemappedDevice.close();
 
     correctlyConfigured = false;
 
@@ -2372,6 +2667,30 @@ bool WholeBodyDynamicsDevice::resetOffset(const std::string& calib_code)
     yWarning() << "wholeBodyDynamics : calib ignoring calib_code " << calib_code;
 
     this->setFTSensorOffsetsToZero();
+
+    return true;
+}
+
+bool WholeBodyDynamicsDevice::usePreEstimatedOffset()
+{
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
+
+    yWarning() << "wholeBodyDynamics : using offset estimated offline.";
+
+    for(size_t ft = 0; ft < this->getNrOfFTSensors(); ft++)
+    {
+        double norm = iDynTree::toEigen(ftProcessors[ft].estimatedOffset()).norm();
+        if (norm!= 0.0){ // if norm is exactly 0.0 it means there was no offset  in the configuration file so it should be skipped
+//TODO: think of a more robust way instead of norm=0.0
+            //The offset estimated offline is meant to be added, while it is substracted in the six axis force torque  measure helpers, so we changed the sign here. There might be a better solution though.
+            yInfo()<< " Value of pre estimated offset is (actual value used is '-' this value): "<< ftProcessors[ft].estimatedOffset().toString() << "for sensor in position "<<ft;
+            ftProcessors[ft].offset()=-ftProcessors[ft].estimatedOffset();
+        }
+        else {
+            yInfo()<< " Norm was exactly 0.0 for ft sensor in position "<<ft<< " so we are using offset calculated using calib all";
+        }
+
+    }
 
     return true;
 }
@@ -2643,5 +2962,3 @@ wholeBodyDynamicsDeviceFilters::~wholeBodyDynamicsDeviceFilters()
 
 }
 }
-
-

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -1458,6 +1458,7 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
     //std::vector<std::string>     tempDeviceNames;
     std::vector<IAnalogSensor *> ftList;
     std::vector<std::string>     ftDeviceNames;
+    std::vector<std::string>     ftAnalogSensorNames;
     for(auto devIdx = 0; devIdx <p.size(); devIdx++)
     {
         ISixAxisForceTorqueSensors * fts = nullptr;
@@ -1475,6 +1476,7 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
             {
                 ftList.push_back(pAnalogSens);
                 ftDeviceNames.push_back(p[devIdx]->key);
+                ftAnalogSensorNames.push_back(p[devIdx]->key);
             }
         }
 
@@ -1540,7 +1542,7 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
     }
     if (checkCounter!=tempSensors){
         yError("wholeBodyDynamics : Not all temperature sensors have the same name as the ft sensors, expected %d , found %d",tempSensors,checkCounter);
-
+        return false;
     }
     //End of temporary temperature check
 
@@ -1557,7 +1559,7 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
         int deviceThatHasTheSameNameOfTheSensor = -1;
         for(size_t deviceIdx = 0; deviceIdx < ftList.size(); deviceIdx++)
         {
-            if( ftDeviceNames[deviceIdx] == sensorName )
+            if( ftAnalogSensorNames[deviceIdx] == sensorName )
             {
                 deviceThatHasTheSameNameOfTheSensor = deviceIdx;
             }

--- a/idl/wholeBodyDynamics_IDLServer/autogenerated/include/wholeBodyDynamics_IDLServer.h
+++ b/idl/wholeBodyDynamics_IDLServer/autogenerated/include/wholeBodyDynamics_IDLServer.h
@@ -97,6 +97,13 @@ public:
     virtual bool resetOffset(const std::string& calib_code);
 
     /**
+     * Use the offline estimated offset of the sensor.
+     * Only sensors with a specified offset in configuration file are affected by this method.s
+     * @return true/false on success/failure
+     */
+    virtual bool usePreEstimatedOffset();
+
+    /**
      * Quit the module.
      * @return true/false on success/failure
      */

--- a/idl/wholeBodyDynamics_IDLServer/autogenerated/src/wholeBodyDynamics_IDLServer.cpp
+++ b/idl/wholeBodyDynamics_IDLServer/autogenerated/src/wholeBodyDynamics_IDLServer.cpp
@@ -393,6 +393,49 @@ bool wholeBodyDynamics_IDLServer_resetOffset_helper::read(yarp::os::ConnectionRe
     return true;
 }
 
+class wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper :
+        public yarp::os::Portable
+{
+public:
+    explicit wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper();
+    bool write(yarp::os::ConnectionWriter& connection) const override;
+    bool read(yarp::os::ConnectionReader& connection) override;
+
+    thread_local static bool s_return_helper;
+};
+
+thread_local bool wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::s_return_helper = {};
+
+wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper()
+{
+    s_return_helper = {};
+}
+
+bool wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::write(yarp::os::ConnectionWriter& connection) const
+{
+    yarp::os::idl::WireWriter writer(connection);
+    if (!writer.writeListHeader(1)) {
+        return false;
+    }
+    if (!writer.writeTag("usePreEstimatedOffset", 1, 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::read(yarp::os::ConnectionReader& connection)
+{
+    yarp::os::idl::WireReader reader(connection);
+    if (!reader.readListReturn()) {
+        return false;
+    }
+    if (!reader.readBool(s_return_helper)) {
+        reader.fail();
+        return false;
+    }
+    return true;
+}
+
 class wholeBodyDynamics_IDLServer_quit_helper :
         public yarp::os::Portable
 {
@@ -1216,6 +1259,16 @@ bool wholeBodyDynamics_IDLServer::resetOffset(const std::string& calib_code)
     return ok ? wholeBodyDynamics_IDLServer_resetOffset_helper::s_return_helper : bool{};
 }
 
+bool wholeBodyDynamics_IDLServer::usePreEstimatedOffset()
+{
+    wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper helper{};
+    if (!yarp().canWrite()) {
+        yError("Missing server method '%s'?", "bool wholeBodyDynamics_IDLServer::usePreEstimatedOffset()");
+    }
+    bool ok = yarp().write(helper, helper);
+    return ok ? wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::s_return_helper : bool{};
+}
+
 bool wholeBodyDynamics_IDLServer::quit()
 {
     wholeBodyDynamics_IDLServer_quit_helper helper{};
@@ -1390,6 +1443,7 @@ std::vector<std::string> wholeBodyDynamics_IDLServer::help(const std::string& fu
         helpString.emplace_back("calibStandingOnOneLink");
         helpString.emplace_back("calibStandingOnTwoLinks");
         helpString.emplace_back("resetOffset");
+        helpString.emplace_back("usePreEstimatedOffset");
         helpString.emplace_back("quit");
         helpString.emplace_back("resetSimpleLeggedOdometry");
         helpString.emplace_back("changeFixedLinkSimpleLeggedOdometry");
@@ -1467,6 +1521,12 @@ std::vector<std::string> wholeBodyDynamics_IDLServer::help(const std::string& fu
             helpString.emplace_back("bool resetOffset(const std::string& calib_code) ");
             helpString.emplace_back("Reset the sensor offset to 0 0 0 0 0 0 (six zeros). ");
             helpString.emplace_back("@param calib_code argument to specify the sensors to reset (all,arms,legs,feet) ");
+            helpString.emplace_back("@return true/false on success/failure ");
+        }
+        if (functionName == "usePreEstimatedOffset") {
+            helpString.emplace_back("bool usePreEstimatedOffset() ");
+            helpString.emplace_back("Use the offline estimated offset of the sensor. ");
+            helpString.emplace_back("Only sensors with a specified offset in configuration file are affected by this method.s ");
             helpString.emplace_back("@return true/false on success/failure ");
         }
         if (functionName == "quit") {
@@ -1741,6 +1801,20 @@ bool wholeBodyDynamics_IDLServer::read(yarp::os::ConnectionReader& connection)
                     return false;
                 }
                 if (!writer.writeBool(wholeBodyDynamics_IDLServer_resetOffset_helper::s_return_helper)) {
+                    return false;
+                }
+            }
+            reader.accept();
+            return true;
+        }
+        if (tag == "usePreEstimatedOffset") {
+            wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::s_return_helper = usePreEstimatedOffset();
+            yarp::os::idl::WireWriter writer(reader);
+            if (!writer.isNull()) {
+                if (!writer.writeListHeader(1)) {
+                    return false;
+                }
+                if (!writer.writeBool(wholeBodyDynamics_IDLServer_usePreEstimatedOffset_helper::s_return_helper)) {
                     return false;
                 }
             }

--- a/idl/wholeBodyDynamics_IDLServer/wholeBodyDynamics_IDLServer.thrift
+++ b/idl/wholeBodyDynamics_IDLServer/wholeBodyDynamics_IDLServer.thrift
@@ -81,6 +81,13 @@ service wholeBodyDynamics_IDLServer
   bool resetOffset(1:string calib_code)
 
   /**
+   * Use the offline estimated offset of the sensor.
+   * Only sensors with a specified offset in configuration file are affected by this method.s
+   * @return true/false on success/failure
+   */
+  bool usePreEstimatedOffset()
+
+  /**
   * Quit the module.
   * @return true/false on success/failure
   */


### PR DESCRIPTION
This PR ports the functionality of considering temperature coefficients in the FT sensors and allows the user to enable if he wants to use an FT offset estimated offline.

It was orignally in [codyco-modules](https://github.com/robotology/codyco-modules/pull/281) and now ported to this repo.