### PR TITLE
[Actions] Add cache action to cache source-based dependency builds and add release versioning to source-based dependencies 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,16 @@ jobs:
             sudo apt install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev
+                             
+        - name: Cache Source-based dependencies
+          id: cache-source-deps
+          uses: actions/cache@v1
+          with:
+            path: ${{ github.workspace }}/install/deps
+            key: source-deps-${{runner.os}}-vcpkg-robotology-${{env.vcpkg_robotology_TAG}}-ycm-${{env.YCM_TAG}}-yarp-${{env.YARP_TAG}}-icub-main-${{env.ICUB_TAG}}-iDynTree-${{env.iDynTree_TAG}}
                                                         
         - name: Source-based Dependencies [Windows]
-          if: matrix.os == 'windows-latest'
+          if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
           shell: bash
           run: |
             # YCM
@@ -89,7 +96,7 @@ jobs:
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
              
             # YARP
@@ -100,8 +107,8 @@ jobs:
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
             # Workaround for https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports/issues/3
             export IPOPT_DIR=${VCPKG_INSTALLATION_ROOT}/installed/x64-windows
@@ -114,9 +121,9 @@ jobs:
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
-                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
             
             # iDynTree
@@ -127,15 +134,15 @@ jobs:
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                          -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON \
-                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
                            
              
         - name: Source-based Dependencies [Ubuntu/macOS]
-          if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+          if: steps.cache-source-deps.outputs.cache-hit != 'true' && (matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest')
           shell: bash
           run: |
             # YCM
@@ -144,7 +151,7 @@ jobs:
             cd ycm
             mkdir -p build
             cd build
-            cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+            cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
              
             # YARP
@@ -154,8 +161,8 @@ jobs:
             git checkout ${YARP_TAG}
             mkdir -p build
             cd build
-            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
                                                     
             # ICUB
@@ -165,8 +172,8 @@ jobs:
             git checkout ${ICUB_TAG}
             mkdir -p build
             cd build
-            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
-                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
             
             # iDynTree
@@ -174,12 +181,11 @@ jobs:
             git clone https://github.com/robotology/iDynTree
             cd iDynTree
             git checkout ${iDynTree_TAG}
-            git checkout devel
             mkdir -p build
             cd build
-            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DIDYNTREE_USES_ICUB_MAIN:BOOL=ON \
-                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
               
         # ===================
@@ -194,7 +200,7 @@ jobs:
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                          -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
             
@@ -204,7 +210,7 @@ jobs:
           run: |
             mkdir -p build
             cd build
-            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
         
         # Build step          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ on:
     # Execute a "nightly" build at 2 AM UTC
     - cron: '0 2 * * *'
     
+env:
+    vcpkg_robotology_TAG: v0.0.3
+    YCM_TAG: v0.11.0
+    YARP_TAG: v3.3.2
+    ICUB_TAG: v1.15.0
+    iDynTree_TAG: v1.0.2   
+    
 jobs:
     build:
         name: '[${{matrix.os}}@${{matrix.build_type}}]'
@@ -45,8 +52,18 @@ jobs:
         - name: Dependencies [Windows]
           if: matrix.os == 'windows-latest'
           run: |
-            git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports      
-            vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace assimp libxml2 eigen3 ipopt-binary
+            # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need
+            choco install -y wget unzip
+            
+            # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/robotology/vcpkg 
+            # that has been used to create the pre-compiled archive
+            cd C:/
+            md C:/robotology
+            md C:/robotology/vcpkg
+            wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
+            unzip vcpkg-robotology.zip -d C:/robotology/vcpkg
+            # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by Github Actions to point to our vcpkg
+            echo "::set-env name=VCPKG_INSTALLATION_ROOT::C:/robotology/vcpkg"
                
         - name: Dependencies [macOS]
           if: matrix.os == 'macOS-latest'
@@ -60,14 +77,14 @@ jobs:
             sudo apt install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
                              libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev
-                             
+                                                        
         - name: Source-based Dependencies [Windows]
           if: matrix.os == 'windows-latest'
           shell: bash
           run: |
             # YCM
             cd ${GITHUB_WORKSPACE}
-            git clone https://github.com/robotology/ycm
+            git clone -b ${YCM_TAG} https://github.com/robotology/ycm
             cd ycm
             mkdir -p build
             cd build
@@ -79,6 +96,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/yarp
             cd yarp
+            git checkout ${YARP_TAG}
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
@@ -92,6 +110,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/icub-main
             cd icub-main
+            git checkout ${ICUB_TAG}
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
@@ -104,7 +123,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/iDynTree
             cd iDynTree
-            git checkout devel
+            git checkout ${iDynTree_TAG}
             mkdir -p build
             cd build
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
@@ -121,7 +140,7 @@ jobs:
           run: |
             # YCM
             cd ${GITHUB_WORKSPACE}
-            git clone https://github.com/robotology/ycm
+            git clone -b ${YCM_TAG} https://github.com/robotology/ycm
             cd ycm
             mkdir -p build
             cd build
@@ -132,6 +151,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/yarp
             cd yarp
+            git checkout ${YARP_TAG}
             mkdir -p build
             cd build
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
@@ -142,6 +162,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/icub-main
             cd icub-main
+            git checkout ${ICUB_TAG}
             mkdir -p build
             cd build
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install \
@@ -152,6 +173,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/iDynTree
             cd iDynTree
+            git checkout ${iDynTree_TAG}
             git checkout devel
             mkdir -p build
             cd build


### PR DESCRIPTION
- Achieve faster workflow CI builds through,
  - pre-compiled vcpkg archives
  - caching source-based dependency builds

- Add release based versioning for source-based dependencies

Inspired and duplicated from
- https://github.com/robotology/idyntree/pull/655
- https://github.com/dic-iit/bipedal-locomotion-controllers/pull/32
- https://github.com/dic-iit/element_jet-cat-turbines/pull/223