### PR TITLE
[wholebodyDynamics] Fix YARP and iDynTree related deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed launch-wholebodydynamics-`*`.xml configuration files in order to properly open `wholebodydynamics` device without silently skipping it. (See [!56](https://github.com/robotology/whole-body-estimators/pull/56)).
+- Fixed a few YARP related and iDynTree related deprecations in `wholebodydynamics`, `genericSensorClient` and `baseEstimatorV1`.
 
 ### Added
 - Github Workflows to check compilation on `ubuntu-latest`, `macOS-latest` and `windows-latest`. (See [!47](https://github.com/robotology/whole-body-estimators/pull/47)).

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -29,7 +29,6 @@
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/GenericSensorInterfaces.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/eigen/Eigen.h>
 #include <yarp/sig/Vector.h>
 #include <yarp/sig/Matrix.h>

--- a/devices/genericSensorClient/GenericSensorClient.cpp
+++ b/devices/genericSensorClient/GenericSensorClient.cpp
@@ -10,8 +10,6 @@
 #include <yarp/os/PortReaderBuffer.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
-#include <yarp/os/LockGuard.h>
-
 
 const int GS_ANALOG_TIMEOUT=100; //ms
 
@@ -19,7 +17,7 @@ using namespace yarp::os;
 
 inline void GSInputPortProcessor::resetStat()
 {
-    yarp::os::LockGuard guard(mutex);
+    std::lock_guard<std::mutex> guard(mutex);
 
     dataAvailable = false;
     count=0;
@@ -39,7 +37,7 @@ void GSInputPortProcessor::onRead(yarp::sig::Vector &v)
 {
     now=Time::now();
 
-    yarp::os::LockGuard guard(mutex);
+    std::lock_guard<std::mutex> guard(mutex);
 
     if (count>0)
     {
@@ -83,7 +81,7 @@ void GSInputPortProcessor::onRead(yarp::sig::Vector &v)
 
 inline bool GSInputPortProcessor::getLast(yarp::sig::Vector &data, Stamp &stmp)
 {
-    yarp::os::LockGuard guard(mutex);
+    std::lock_guard<std::mutex> guard(mutex);
 
     if (dataAvailable)
     {
@@ -96,7 +94,7 @@ inline bool GSInputPortProcessor::getLast(yarp::sig::Vector &data, Stamp &stmp)
 
 inline int GSInputPortProcessor::getIterations()
 {
-    yarp::os::LockGuard guard(mutex);
+    std::lock_guard<std::mutex> guard(mutex);
 
     int ret=count;
     return ret;
@@ -105,7 +103,7 @@ inline int GSInputPortProcessor::getIterations()
 // time is in ms
 void GSInputPortProcessor::getEstFrequency(int &ite, double &av, double &min, double &max)
 {
-    yarp::os::LockGuard guard(mutex);
+    std::lock_guard<std::mutex> guard(mutex);
 
     ite=count;
     min=deltaTMin*1000;
@@ -134,7 +132,7 @@ int GSInputPortProcessor::getChannels()
 
 bool yarp::dev::GenericSensorClient::open(yarp::os::Searchable &config)
 {
-    ConstString carrier = config.check("carrier", Value("udp"), "default carrier for streaming robot state").asString().c_str();
+    std::string carrier = config.check("carrier", Value("udp"), "default carrier for streaming robot state").asString().c_str();
 
     local.clear();
     remote.clear();

--- a/devices/genericSensorClient/GenericSensorClient.h
+++ b/devices/genericSensorClient/GenericSensorClient.h
@@ -13,9 +13,12 @@
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/dev/GenericSensorInterfaces.h>
 #include <yarp/sig/Vector.h>
-#include <yarp/os/Semaphore.h>
+
 #include <yarp/os/Time.h>
 #include <yarp/dev/PolyDriver.h>
+
+#include <mutex>
+#include <string>
 
 /**
  * Class copied from the InputPortProcessor class in AnalogSensorClient.
@@ -23,7 +26,7 @@
  */
 class GSInputPortProcessor : public yarp::os::BufferedPort<yarp::sig::Vector>
 {
-    yarp::os::Mutex mutex;
+    std::mutex mutex;
     yarp::sig::Vector lastVector;
     yarp::os::Stamp lastStamp;
     double deltaT;
@@ -85,8 +88,8 @@ class GenericSensorClient: public yarp::dev::DeviceDriver,
 {
 protected:
     GSInputPortProcessor inputPort;
-    yarp::os::ConstString local;
-    yarp::os::ConstString remote;
+    std::string local;
+    std::string remote;
     yarp::os::Stamp lastTs; //used by IPreciselyTimed
 
     void  removeLeadingTrailingSlashesOnly(std::string &name);

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -862,7 +862,7 @@ bool WholeBodyDynamicsDevice::loadGravityCompensationSettingsFromConfig(os::Sear
 
 bool WholeBodyDynamicsDevice::open(os::Searchable& config)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     bool ok;
 
@@ -1124,7 +1124,7 @@ bool WholeBodyDynamicsDevice::attachAllIMUs(const PolyDriverList& p)
 
 bool WholeBodyDynamicsDevice::attachAll(const PolyDriverList& p)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     bool ok = true;
     ok = ok && this->attachAllControlBoard(p);
@@ -1815,7 +1815,7 @@ void WholeBodyDynamicsDevice::publishFilteredFTWithoutOffset()
 
 void WholeBodyDynamicsDevice::run()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     if( correctlyConfigured )
     {
@@ -1847,7 +1847,7 @@ void WholeBodyDynamicsDevice::run()
 
 bool WholeBodyDynamicsDevice::detachAll()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     correctlyConfigured = false;
 
@@ -1974,7 +1974,7 @@ bool WholeBodyDynamicsDevice::setupCalibrationWithExternalWrenchesOnTwoFrames(co
 
 bool WholeBodyDynamicsDevice::calib(const std::string& calib_code, const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yWarning() << "wholeBodyDynamics : calib ignoring calib_code " << calib_code;
 
@@ -1991,7 +1991,7 @@ bool WholeBodyDynamicsDevice::calib(const std::string& calib_code, const int32_t
 
 bool WholeBodyDynamicsDevice::calibStanding(const std::string& calib_code, const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yWarning() << "wholeBodyDynamics : calibStanding ignoring calib_code " << calib_code;
 
@@ -2008,7 +2008,7 @@ bool WholeBodyDynamicsDevice::calibStanding(const std::string& calib_code, const
 
 bool WholeBodyDynamicsDevice::calibStandingLeftFoot(const std::string& calib_code, const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yWarning() << " wholeBodyDynamics : calibStandingLeftFoot ignoring calib_code " << calib_code;
 
@@ -2024,7 +2024,7 @@ bool WholeBodyDynamicsDevice::calibStandingLeftFoot(const std::string& calib_cod
 
 bool WholeBodyDynamicsDevice::calibStandingRightFoot(const std::string& calib_code, const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yWarning() << " wholeBodyDynamics : calibStandingRightFoot ignoring calib_code " << calib_code;
 
@@ -2041,7 +2041,7 @@ bool WholeBodyDynamicsDevice::calibStandingRightFoot(const std::string& calib_co
 
 bool WholeBodyDynamicsDevice::calibStandingOnOneLink(const std::string &standing_frame, const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     bool ok = this->setupCalibrationWithExternalWrenchOnOneFrame(standing_frame,nr_of_samples);
 
@@ -2057,7 +2057,7 @@ bool WholeBodyDynamicsDevice::calibStandingOnTwoLinks(const std::string &first_s
                                                       const std::string &second_standing_frame,
                                                       const int32_t nr_of_samples)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     bool ok = this->setupCalibrationWithExternalWrenchesOnTwoFrames(first_standing_frame,second_standing_frame,nr_of_samples);
 
@@ -2071,7 +2071,7 @@ bool WholeBodyDynamicsDevice::calibStandingOnTwoLinks(const std::string &first_s
 
 bool WholeBodyDynamicsDevice::resetOffset(const std::string& calib_code)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yWarning() << "wholeBodyDynamics : calib ignoring calib_code " << calib_code;
 
@@ -2092,14 +2092,14 @@ bool WholeBodyDynamicsDevice::changeFixedLinkSimpleLeggedOdometry(const std::str
 
 double WholeBodyDynamicsDevice::get_forceTorqueFilterCutoffInHz()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     return this->settings.forceTorqueFilterCutoffInHz;
 }
 
 bool WholeBodyDynamicsDevice::set_forceTorqueFilterCutoffInHz(const double newCutoff)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.forceTorqueFilterCutoffInHz = newCutoff;
 
@@ -2108,14 +2108,14 @@ bool WholeBodyDynamicsDevice::set_forceTorqueFilterCutoffInHz(const double newCu
 
 double WholeBodyDynamicsDevice::get_jointVelFilterCutoffInHz()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     return this->settings.jointVelFilterCutoffInHz;
 }
 
 bool WholeBodyDynamicsDevice::set_jointVelFilterCutoffInHz(const double newCutoff)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.jointVelFilterCutoffInHz = newCutoff;
 
@@ -2124,14 +2124,14 @@ bool WholeBodyDynamicsDevice::set_jointVelFilterCutoffInHz(const double newCutof
 
 double WholeBodyDynamicsDevice::get_jointAccFilterCutoffInHz()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     return this->settings.jointAccFilterCutoffInHz;
 }
 
 bool WholeBodyDynamicsDevice::set_jointAccFilterCutoffInHz(const double newCutoff)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.jointAccFilterCutoffInHz = newCutoff;
 
@@ -2141,14 +2141,14 @@ bool WholeBodyDynamicsDevice::set_jointAccFilterCutoffInHz(const double newCutof
 
 double WholeBodyDynamicsDevice::get_imuFilterCutoffInHz()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     return this->settings.imuFilterCutoffInHz;
 }
 
 bool WholeBodyDynamicsDevice::set_imuFilterCutoffInHz(const double newCutoff)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.imuFilterCutoffInHz = newCutoff;
 
@@ -2157,7 +2157,7 @@ bool WholeBodyDynamicsDevice::set_imuFilterCutoffInHz(const double newCutoff)
 
 bool WholeBodyDynamicsDevice::useFixedFrameAsKinematicSource(const std::string& fixedFrame)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     iDynTree::FrameIndex fixedFrameIndex = estimator.model().getFrameIndex(fixedFrame);
 
@@ -2179,7 +2179,7 @@ bool WholeBodyDynamicsDevice::useFixedFrameAsKinematicSource(const std::string& 
 
 bool WholeBodyDynamicsDevice::useIMUAsKinematicSource()
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     yInfo() << "wholeBodyDynamics : successfully set the kinematic source to be the IMU ";
 
@@ -2190,7 +2190,7 @@ bool WholeBodyDynamicsDevice::useIMUAsKinematicSource()
 
 bool WholeBodyDynamicsDevice::setUseOfJointVelocities(const bool enable)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.useJointVelocity = enable;
 
@@ -2199,7 +2199,7 @@ bool WholeBodyDynamicsDevice::setUseOfJointVelocities(const bool enable)
 
 bool WholeBodyDynamicsDevice::setUseOfJointAccelerations(const bool enable)
 {
-    yarp::os::LockGuard guard(this->deviceMutex);
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     this->settings.useJointAcceleration = enable;
 
@@ -2208,7 +2208,7 @@ bool WholeBodyDynamicsDevice::setUseOfJointAccelerations(const bool enable)
 
 std::string WholeBodyDynamicsDevice::getCurrentSettingsString()
 {
-   yarp::os::LockGuard guard(this->deviceMutex);
+   std::lock_guard<std::mutex> guard(this->deviceMutex);
 
    return settings.toString();
 }

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -1,7 +1,6 @@
 #define SKIN_EVENTS_TIMEOUT 0.2
 #include "WholeBodyDynamicsDevice.h"
 
-#include <yarp/os/LockGuard.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/ResourceFinder.h>

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -10,7 +10,7 @@
 #include <yarp/dev/Wrapper.h>
 #include <yarp/os/RateThread.h>
 #include <yarp/os/RpcServer.h>
-#include <yarp/os/Semaphore.h>
+//#include <yarp/os/Semaphore.h>
 #include <yarp/dev/IVirtualAnalogSensor.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/GenericSensorInterfaces.h>
@@ -32,6 +32,7 @@
 #include "GravityCompensationHelpers.h"
 
 #include <vector>
+#include <mutex>
 
 
 namespace yarp {
@@ -333,7 +334,7 @@ private:
         yarp::dev::IEncoders        * encs;
         yarp::dev::IMultipleWrapper * multwrap;
         yarp::dev::IImpedanceControl * impctrl;
-        yarp::dev::IControlMode2    * ctrlmode;
+        yarp::dev::IControlMode    * ctrlmode;
         yarp::dev::IInteractionMode * intmode;
     } remappedControlBoardInterfaces;
 
@@ -365,7 +366,7 @@ private:
      * (managed by the yarprobotinterface thread) and by the RPC call
      * invoked by the RPC thread.
      */
-    yarp::os::Mutex deviceMutex;
+    std::mutex deviceMutex;
 
     /**
      * A port for editing remotly the setting of wholeBodyDynamics

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -20,7 +20,7 @@
 
 // iDynTree includes
 #include <iDynTree/Estimation/ExtWrenchesAndJointTorquesEstimator.h>
-#include <iDynTree/iCub/skinDynLibConversions.h>
+#include <iDynTree/skinDynLibConversions.h>
 #include <iDynTree/KinDynComputations.h>
 
 // Filters

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -10,7 +10,6 @@
 #include <yarp/dev/Wrapper.h>
 #include <yarp/os/RateThread.h>
 #include <yarp/os/RpcServer.h>
-//#include <yarp/os/Semaphore.h>
 #include <yarp/dev/IVirtualAnalogSensor.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/GenericSensorInterfaces.h>


### PR DESCRIPTION
This PR addresses the following changes in wholebodydynamics device,
- Handles yarp::os::Mutex deprecation with std::mutex and std::lock_guard
- Handles yarp::dev::IControlMode2 deprecation with yarp::dev::IControlMode
- Handles iDynTree/iCub/skinDynLibConversions deprecation with iDynTree/skinDynLibConversions
- Additional changes related to deprecations in LockGuard and ConstString specifications in `wholebodydynamics`, `genericSensorClient` and `baseEstimatorV1`.
Fixes #57 