### PR TITLE
Finding Eigen3 and properly link it when using EigenHelpers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(whole-body-estimators LANGUAGES CXX
                               VERSION 0.2)
-                             
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -31,6 +31,7 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BIND
 set(YARP_REQUIRED_VERSION 3.0.1)
 
 find_package(YARP ${YARP_REQUIRED_VERSION} REQUIRED)
+find_package(Eigen3 3.2.92 REQUIRED)
 
 yarp_configure_plugins_installation(${PROJECT_NAME})
 

--- a/devices/baseEstimatorV1/CMakeLists.txt
+++ b/devices/baseEstimatorV1/CMakeLists.txt
@@ -34,12 +34,12 @@ set_property(TARGET floatingBaseEstimationRPC-service PROPERTY POSITION_INDEPEND
 yarp_add_plugin(baseEstimatorV1  ${FBE_SOURCES} ${FBE_HEADERS})
 
 target_include_directories(baseEstimatorV1 PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}/include
-                           ${Eigen3_INCLUDE_DIRS})
+                           ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(baseEstimatorV1 ${YARP_LIBRARIES}
+target_link_libraries(baseEstimatorV1 PUBLIC ${YARP_LIBRARIES}
                                       ${iDynTree_LIBRARIES}
-                                      floatingBaseEstimationRPC-service)
+                                      floatingBaseEstimationRPC-service
+                                      PRIVATE Eigen3::Eigen)
 
 yarp_install(TARGETS baseEstimatorV1
              COMPONENT Runtime


### PR DESCRIPTION
See https://github.com/robotology/osqp-eigen/issues/61 for details. In brief, when using ``OsqpEigen`` in ``devel``, by a chain reaction,  this repo fails to compile.