### PR TITLE
Require iDynTree v1.1.0 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
     YCM_TAG: v0.11.0
     YARP_TAG: v3.3.2
     ICUB_TAG: v1.15.0
-    iDynTree_TAG: v1.0.2   
+    iDynTree_TAG: v1.1.0   
     
 jobs:
     build:


### PR DESCRIPTION
iDynTree compilation was failing in Windows Visual Studio due to a missing `<string>` header in Triplets.h (Original issue https://github.com/robotology/idyntree/issues/671). This was reflected in our CI workflow as well, See [here](https://github.com/robotology/whole-body-estimators/runs/740774705?check_suite_focus=true). 

This was fixed in https://github.com/robotology/idyntree/pull/672.

Related issue: https://github.com/dic-iit/bipedal-locomotion-framework/pull/49