### PR TITLE
Remove unused code, fix configuration and update documentation 

### DIFF
--- a/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/launch-fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/launch-fbe-analogsens.xml
@@ -9,32 +9,6 @@
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="iCubGazeboV2_5" portprefix="baseestimation" build="1"  xmlns:xi="http://www.w3.org/2001/XInclude">
 
-    <!-- open control boards -->
-    <device name="torso_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/torso</param>
-        <param name="local">/baseestimation/torso</param>
-    </device>
-    <device name="left_arm_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/left_arm</param>
-        <param name="local">/baseestimation/left_arm</param>
-    </device>
-    <device name="right_arm_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/right_arm</param>
-        <param name="local">/baseestimation/right_arm</param>
-    </device>
-    <device name="left_leg_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/left_leg</param>
-        <param name="local">/baseestimation/left_leg</param>
-    </device>
-    <device name="right_leg_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/right_leg</param>
-        <param name="local">/baseestimation/right_leg</param>
-    </device>
-    <device name="head_mc" type="remote_controlboard">
-        <param name="remote">/icubSim/head</param>
-        <param name="local">/baseestimation/head</param>
-    </device>
-
     <!-- open remote control board remapper -->
     <device name="all_joints_mc" type="remotecontrolboardremapper">
         <param name="remoteControlBoards">("/icubSim/head", "/icubSim/torso", "/icubSim/left_arm", "/icubSim/right_arm", "/icubSim/left_leg", "/icubSim/right_leg")</param>

--- a/devices/baseEstimatorV1/app/robots/iCubGenova04/launch-fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGenova04/launch-fbe-analogsens.xml
@@ -8,32 +8,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="iCubGenova04" portprefix="baseestimation" build="1"  xmlns:xi="http://www.w3.org/2001/XInclude">
-    <!-- open control boards -->
-    <device name="torso_mc" type="remote_controlboard">
-        <param name="remote">/icub/torso</param>
-        <param name="local">/baseestimation/torso</param>
-    </device>
-    <device name="left_arm_mc" type="remote_controlboard">
-        <param name="remote">/icub/left_arm</param>
-        <param name="local">/baseestimation/left_arm</param>
-    </device>
-    <device name="right_arm_mc" type="remote_controlboard">
-        <param name="remote">/icub/right_arm</param>
-        <param name="local">/baseestimation/right_arm</param>
-    </device>
-    <device name="left_leg_mc" type="remote_controlboard">
-        <param name="remote">/icub/left_leg</param>
-        <param name="local">/baseestimation/left_leg</param>
-    </device>
-    <device name="right_leg_mc" type="remote_controlboard">
-        <param name="remote">/icub/right_leg</param>
-        <param name="local">/baseestimation/right_leg</param>
-    </device>
-    <device name="head_mc" type="remote_controlboard">
-        <param name="remote">/icub/head</param>
-        <param name="local">/baseestimation/head</param>
-    </device>
-
 
     <!-- open remote control board remapper -->
     <device name="all_joints_mc" type="remotecontrolboardremapper">

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -406,25 +406,29 @@ namespace yarp {
         /**
          * @brief publish internal state of attitude estimator through YARP port
          *        roll pitch yaw omegax omegay omegaz gyrobiasx gyrobiasy gyrobiasz
+         *        here omegax omegay omegaz are expressed in IMU local frame
+         *        orientation is with respect to the inertial frame that the IMU assumes
          */
         void publishIMUAttitudeEstimatorStates();
 
         /**
          * @brief publish internal state of QEKF through YARP port
          *        roll pitch yaw
+         *        orientation is with respect to the inertial frame that the IMU assumes
          */
         void publishIMUAttitudeQEKFEstimates();
 
         /**
          * @brief publish floating base state through YARP port
          *        x y z roll pitch yaw joint_positions
-         *        roll pitch yaw
          */
         void publishFloatingBaseState();
 
         /**
          * @brief publish floating base pose and velocity through YARP port
          *        x y z roll pitch yaw vx vy vz omegax omegay omegaz
+         *        the velocity assumes a mixed-velocity representation
+         *        as defined in [Multibody Dynamics Notation](https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notation_Revision_2_.pdf)
          */
         void publishFloatingBasePoseVelocity();
 

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -385,15 +385,6 @@ namespace yarp {
         bool updateBaseVelocity();
 
         /**
-         * @brief computes the floating base velocity using IMU measurements
-         *        linear velocity is obtained through Euler-integration of linear acceleration
-         *        obtained from the proper sensor acceleration of the IMU
-         *        angular velocity is given by the attitude estimator
-         * @return true/false success/failure
-         */
-        bool updateBaseVelocityWithIMU();
-
-        /**
          * @brief sets robot state for kindyncomputations object using estimated base pose,
          *  kinematic measurements and zero base velocity
          * @return true/false success/failure


### PR DESCRIPTION
- Removed a method updateBaseVelocityWithIMU() which was unused and the internal computations seemed to be wrong. (missing an adjoint velocity transform from IMU frame to base frame)

- Removed redundant opening of `controlboard` devices, which is unused by the estimator device, since we open a remotecontrolboardremapper and the estimator device attaches to this remapper. Thanks to @diegoferigo for spotting this.

- Update documentation. Fixes #81.
