### PR TITLE
Add wholeBodyDynamics configuration files for iCubGazeboV3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added 'startWithZeroFTSensorOffsets' option when passed starts the WBD device with zero offsets for FT sensors, bypassing the offset calibration. (See [!72](https://github.com/robotology/whole-body-estimators/pull/72)).
 - Added support for compensating temperature in Force/Torque sensors readings and for specify user offline offset. (See [!45](https://github.com/robotology/whole-body-estimators/pull/45))
 - Added `useSkinForContacts` option flag to enable/disable the usage of tactile skin sensor information for updating contact points and relevant information. (See [!88](https://github.com/robotology/whole-body-estimators/pull/88))
+- Added `wholeBodyDynamics` configuration files for `iCubGazeboV3`. (See [!90](https://github.com/robotology/whole-body-estimators/pull/90))
 
 ## [0.2.1] - 2020-04-08
 ### Fixed

--- a/devices/wholeBodyDynamics/app/CMakeLists.txt
+++ b/devices/wholeBodyDynamics/app/CMakeLists.txt
@@ -94,3 +94,10 @@ install_wbd_robots_files(YARP_ROBOT_NAME iCubGazeboV2_5
                          EXTERNAL_WBD_CONF wholebodydynamics-icub-external-six-fts-sim.xml
                          EXTERNAL_YRI_CONF launch-wholebodydynamics-icub-six-fts-sim.xml
                          NO_ROBOT)
+                         
+install_wbd_robots_files(YARP_ROBOT_NAME iCubGazeboV3
+                         EXTERNAL_WBD_CONF wholebodydynamics-icub-external-eight-fts-sim.xml
+                         EXTERNAL_YRI_CONF launch-wholebodydynamics-icub-eight-fts-sim.xml
+                         NO_ROBOT)
+                         
+                         

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-eight-fts-sim.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-eight-fts-sim.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="@WBD_YARP_ROBOT_NAME@" build="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <!-- controlboards -->
+    <device name="torso_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/torso </param>
+        <param name="local"> /wholeBodyDynamics/torso </param>
+    </device>
+
+    <device name="left_arm_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/left_arm </param>
+        <param name="local"> /wholeBodyDynamics/left_arm </param>
+    </device>
+
+    <device name="right_arm_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/right_arm </param>
+        <param name="local"> /wholeBodyDynamics/right_arm </param>
+    </device>
+
+    <device name="left_leg_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/left_leg </param>
+        <param name="local"> /wholeBodyDynamics/left_leg </param>
+    </device>
+
+    <device name="right_leg_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/right_leg </param>
+        <param name="local"> /wholeBodyDynamics/right_leg </param>
+    </device>
+
+    <device name="head_mc" type="remote_controlboard">
+        <param name="remote"> /icubSim/head </param>
+        <param name="local"> /wholeBodyDynamics/head </param>
+    </device>
+
+    <!-- imu -->
+    <device name="inertial" type="genericSensorClient">
+        <param name="remote"> /icubSim/inertial </param>
+        <param name="local"> /wholeBodyDynamics/imu </param>
+    </device>
+
+    <!-- six axis force torque sensors -->
+    <device name="left_upper_arm_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/left_arm/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/l_arm_ft_sensor </param>
+    </device>
+
+    <device name="right_upper_arm_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/right_arm/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/r_arm_ft_sensor </param>
+    </device>
+
+    <device name="left_upper_leg_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/left_leg/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+    </device>
+
+    <device name="right_upper_leg_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/right_leg/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+    </device>
+
+    <device name="left_lower_leg_front_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/left_foot_front/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_front_ft_sensor </param>
+    </device>
+
+    <device name="left_lower_leg_rear_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/left_foot_rear/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_rear_ft_sensor </param>
+    </device>
+
+    <device name="right_lower_leg_front_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/right_foot_front/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_front_ft_sensor </param>
+    </device>
+
+    <device name="right_lower_leg_rear_strain" type="analogsensorclient">
+        <param name="remote"> /icubSim/right_foot_rear/analog:o </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_rear_ft_sensor </param>
+    </device>
+
+    <!-- estimators -->
+    <xi:include href="estimators/wholebodydynamics-external.xml" />
+</robot>

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-eight-fts-sim.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-eight-fts-sim.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<devices robot="@WBD_YARP_ROBOT_NAME@" build="1">
+    <device name="wholebodydynamics" type="wholebodydynamics">
+        <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_prosup,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_prosup,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+        <param name="modelFile">model.urdf</param>
+        <param name="fixedFrameGravity">(0,0,-9.81)</param>
+        <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_foot_front,l_foot_rear,r_foot_front,r_foot_rear,l_upper_leg,r_upper_leg)</param>
+        <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
+        <param name="imuFilterCutoffInHz">3.0</param>
+        <param name="forceTorqueFilterCutoffInHz">3.0</param>
+        <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
+        <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
+        <param name="startWithZeroFTSensorOffsets">true</param> <!-- bypass using resetOffset of FT sensors in simulation -->
+        <param name="useSkinForContacts">false</param>
+
+
+        <group name="GRAVITY_COMPENSATION">
+            <param name="enableGravityCompensation">true</param>
+            <param name="gravityCompensationBaseLink">root_link</param>
+            <param name="gravityCompensationAxesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch,neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow)</param>
+        </group>
+
+        <group name="WBD_OUTPUT_EXTERNAL_WRENCH_PORTS">
+            <param name="/wholeBodyDynamics/left_arm/endEffectorWrench:o">(l_hand,l_hand)</param>
+            <param name="/wholeBodyDynamics/right_arm/endEffectorWrench:o">(r_hand,l_hand)</param>
+            <param name="/wholeBodyDynamics/left_foot_front/cartesianEndEffectorWrench:o">(l_foot_front,l_foot_front,l_foot_front)</param>
+            <param name="/wholeBodyDynamics/left_foot_rear/cartesianEndEffectorWrench:o">(l_foot_rear,l_foot_rear,l_foot_rear)</param>
+            <param name="/wholeBodyDynamics/right_foot_front/cartesianEndEffectorWrench:o">(r_foot_front,r_foot_front,r_foot_front)</param>
+            <param name="/wholeBodyDynamics/right_foot_rear/cartesianEndEffectorWrench:o">(r_foot_rear,r_foot_rear,r_foot_rear)</param>
+
+        </group>
+
+        <action phase="startup" level="15" type="attach">
+            <paramlist name="networks">
+                <!-- motorcontrol -->
+                <elem name="left_leg">left_leg_mc</elem>
+                <elem name="right_leg">right_leg_mc</elem>
+                <elem name="torso">torso_mc</elem>
+                <elem name="right_arm">right_arm_mc</elem>
+                <elem name="left_arm">left_arm_mc</elem>
+                <elem name="head">head_mc</elem>
+                <!-- imu -->
+                <elem name="imu">inertial</elem>
+                <!-- ft -->
+                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
+                <elem name="l_foot_front_ft_sensor">left_lower_leg_front_strain</elem>
+                <elem name="l_foot_rear_ft_sensor">left_lower_leg_rear_strain</elem>
+                <elem name="r_foot_front_ft_sensor">right_lower_leg_front_strain</elem>
+                <elem name="r_foot_rear_ft_sensor">right_lower_leg_rear_strain</elem>
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="2" type="detach" />
+
+    </device>
+</devices>


### PR DESCRIPTION
Requires the iCubGazeboV3 URDF model to contain the IMU sensor added in its `head` link.
This is a pending issue in https://github.com/robotology/icub-models/issues/62.


Temporarily, this can be fixed by adding to the URDF, 

``` xml
  <gazebo reference="head">
    <sensor name="head_imu_acc_1x1" type="imu">
      <always_on>1</always_on>
      <update_rate>100</update_rate>
      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
        <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
            <yarpConfigurationFile>model://iCub/conf_icub3/gazebo_icub_inertial.ini</yarpConfigurationFile>
        </plugin>
    </sensor>
  </gazebo>
  <sensor name="head_imu_acc_1x1" type="accelerometer">
    <parent link="head"/>
    <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
  </sensor>
```
This is done in https://github.com/dic-iit/icub-models/tree/icub3/wbd.