### PR TITLE
Fix unaddressed yarp::os::ConstString deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug in opening the `wholeBodyDynamics` device while using the `assume_fixed` parameter in the configuration instead of `imuFrameName`. (See [!93](https://github.com/robotology/whole-body-estimators/pull/93)).
 - Fixed parsing `checkTemperatureEvery_seconds` parameter in `wholeBodyDynamics` device. (See [!93](https://github.com/robotology/whole-body-estimators/pull/93)).
+- Fix `yarp::os::ConstString` deprecations (See [!94](https://github.com/robotology/whole-body-estimators/pull/94))
 
 ## [0.3.0] - 2020-11-09
 ### Added

--- a/devices/virtualAnalogClient/VirtualAnalogClient.cpp
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.cpp
@@ -43,7 +43,7 @@ bool VirtualAnalogClient::open(Searchable& config)
 
     m_remote = prop.find("remote").asString();
 
-    yarp::os::ConstString carrier;
+    std::string carrier;
     if( ( prop.check("carrier") && prop.find("carrier").isString() ) )
     {
         carrier = prop.find("carrier").asString();
@@ -75,7 +75,7 @@ bool VirtualAnalogClient::open(Searchable& config)
         Bottle * AxisTypeBot = prop.find("AxisType").asList();
         for(int jnt=0; jnt < AxisTypeBot->size(); jnt++)
         {
-            ConstString type = AxisTypeBot->get(jnt).asString();
+            std::string type = AxisTypeBot->get(jnt).asString();
             if (type == "revolute")
             {
                 m_axisType[jnt] = VOCAB_JOINTTYPE_REVOLUTE;
@@ -205,7 +205,7 @@ VAS_status VirtualAnalogClient::getVirtualAnalogSensorStatus(int /*ch*/)
     return yarp::dev::VAS_status::VAS_OK;
 }
 
-bool VirtualAnalogClient::getAxisName(int axis, ConstString& name)
+bool VirtualAnalogClient::getAxisName(int axis, std::string& name)
 {
     if( axis < 0 || axis >= this->getVirtualAnalogSensorChannels() )
     {

--- a/devices/virtualAnalogClient/VirtualAnalogClient.h
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.h
@@ -19,6 +19,7 @@
 #include <yarp/dev/PolyDriver.h>
 
 #include <vector>
+#include <string>
 
 namespace yarp {
 namespace dev {
@@ -57,11 +58,11 @@ class VirtualAnalogClient:    public DeviceDriver,
                               public IAxisInfo
 {
 protected:
-    yarp::os::ConstString m_local;
-    yarp::os::ConstString m_remote;
+    std::string m_local;
+    std::string m_remote;
     int m_virtualAnalogSensorInteger;
 
-    std::vector<yarp::os::ConstString> m_axisName;
+    std::vector<std::string> m_axisName;
     std::vector<yarp::dev::JointTypeEnum> m_axisType;
 
     yarp::os::BufferedPort<yarp::os::Bottle> m_outputPort;
@@ -88,7 +89,7 @@ public:
     virtual bool updateVirtualAnalogSensorMeasure(int ch, double &measure);
 
     /** IAxisInfo methods (documented in IVirtualAnalogSensor class) */
-    virtual bool getAxisName(int axis, yarp::os::ConstString& name);
+    virtual bool getAxisName(int axis, std::string& name);
     virtual bool getJointType(int axis, yarp::dev::JointTypeEnum& type);
 };
 

--- a/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
+++ b/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
@@ -87,7 +87,7 @@ bool VirtualAnalogRemapper::attachAll(const PolyDriverList& p)
         int nrOfVirtualAxes = virtualAnalogList[devIdx]->getVirtualAnalogSensorChannels();
         for(int localAxis=0; localAxis < nrOfVirtualAxes; localAxis++)
         {
-            yarp::os::ConstString axisName;
+            std::string axisName;
             axisInfoList[devIdx]->getAxisName(localAxis,axisName);
 
             std::string axisNameStd = axisName.c_str();
@@ -296,7 +296,7 @@ yarp::dev::VAS_status VirtualAnalogRemapper::getVirtualAnalogSensorStatus(int ch
     return status;
 }
 
-bool VirtualAnalogRemapper::getAxisName(int axis, ConstString& name)
+bool VirtualAnalogRemapper::getAxisName(int axis, std::string& name)
 {
     if( axis < 0 || axis >= this->getVirtualAnalogSensorChannels() )
     {

--- a/devices/virtualAnalogRemapper/VirtualAnalogRemapper.h
+++ b/devices/virtualAnalogRemapper/VirtualAnalogRemapper.h
@@ -13,6 +13,7 @@
 #include <yarp/dev/Wrapper.h>
 
 #include <vector>
+#include <string>
 
 namespace yarp {
 namespace dev {
@@ -126,7 +127,7 @@ public:
     virtual bool updateVirtualAnalogSensorMeasure(int ch, double &measure);
     
     /** IAxisInfo methods (documented in IVirtualAnalogSensor class) */
-    virtual bool getAxisName(int axis, yarp::os::ConstString& name);
+    virtual bool getAxisName(int axis, std::string& name);
     virtual bool getJointType(int axis, yarp::dev::JointTypeEnum& type);
 
     /** IMultipleWrapper methods (documented in IMultipleWrapper */


### PR DESCRIPTION
There were a few unaddressed const string deprecations in virtual analog remapper and clients.