### PR TITLE
[WBD] Add `calibStandingWithJetsiRonCubMk1` rpc command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added a `yarp rpc` comand `alibStandingWithJetsiRonCubMk1` that performs `calibStanding` for `iRonCub-Mk1` model/robot when the jets are ON and on `idle` thrust. (See [!113](https://github.com/robotology/whole-body-estimators/pull/113)).
+- Added a `yarp rpc` comand `calibStandingWithJetsiRonCubMk1` that performs `calibStanding` for `iRonCub-Mk1` model/robot when the jets are ON and on `idle` thrust. (See [!113](https://github.com/robotology/whole-body-estimators/pull/113)).
 - Added an optional config parameter list of fixed joints `additionalConsideredFixedJoints` being omitted by the URDF model parser but are needed to be considered in the joint list. (See [!109](https://github.com/robotology/whole-body-estimators/pull/109)).
 - Added some debug prints to detect where the wholeBodyDynamics device hangs at startup. (See [!106](https://github.com/robotology/whole-body-estimators/pull/106)).
 - Fixed the configuration files to run wholeBodyDynamics with iCubGazeboV3. (See [!107](https://github.com/robotology/whole-body-estimators/pull/107)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added a `yarp rpc` comand `alibStandingWithJetsiRonCubMk1` that performs `calibStanding` for `iRonCub-Mk1` model/robot when the jets are ON and on `idle` thrust. (See [!113](https://github.com/robotology/whole-body-estimators/pull/113)).
 - Added an optional config parameter list of fixed joints `additionalConsideredFixedJoints` being omitted by the URDF model parser but are needed to be considered in the joint list. (See [!109](https://github.com/robotology/whole-body-estimators/pull/109)).
 - Added some debug prints to detect where the wholeBodyDynamics device hangs at startup. (See [!106](https://github.com/robotology/whole-body-estimators/pull/106)).
 - Fixed the configuration files to run wholeBodyDynamics with iCubGazeboV3. (See [!107](https://github.com/robotology/whole-body-estimators/pull/107)).

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -2889,8 +2889,9 @@ bool WholeBodyDynamicsDevice::setupCalibrationWithVerticalForcesOnTheFeetAndJets
 
     // We assume that all the 6 contacts are Pure Forces with Known Directions (1D) at the origin of each frame
     iDynTree::Direction zPosAxis = iDynTree::Direction(0,0,1);
-    double p100ThrustN = 2;
-    double p220ThrustN = 9;
+    iDynTree::Direction zNegAxis = iDynTree::Direction(0,0,-1);
+    double p100ThrustN = -2;
+    double p220ThrustN = -9;
     iDynTree::Force jetArmForce = iDynTree::Force(0,0,p100ThrustN);
     iDynTree::Torque jetArmTorque = iDynTree::Torque(0,0,0);
     iDynTree::Wrench jetArmWrench = iDynTree::Wrench(jetArmForce, jetArmTorque);
@@ -2899,8 +2900,8 @@ bool WholeBodyDynamicsDevice::setupCalibrationWithVerticalForcesOnTheFeetAndJets
     iDynTree::Torque jetBackTorque = iDynTree::Torque(0,0,0);
     iDynTree::Wrench jetBackWrench = iDynTree::Wrench(jetBackForce, jetBackTorque);
 
-    iDynTree::UnknownWrenchContact calibrationAssumedArmJetContact(iDynTree::NO_UNKNOWNS,iDynTree::Position::Zero(),iDynTree::Direction::Default(), jetArmWrench);
-    iDynTree::UnknownWrenchContact calibrationAssumedBackJetContact(iDynTree::NO_UNKNOWNS,iDynTree::Position::Zero(),iDynTree::Direction::Default(), jetBackWrench);
+    iDynTree::UnknownWrenchContact calibrationAssumedArmJetContact(iDynTree::NO_UNKNOWNS,iDynTree::Position::Zero(),zPosAxis, jetArmWrench);
+    iDynTree::UnknownWrenchContact calibrationAssumedBackJetContact(iDynTree::NO_UNKNOWNS,iDynTree::Position::Zero(),zPosAxis, jetBackWrench);
 
     // Add jets contacts
     bool ok = calibrationBuffers.assumedContactLocationsForCalibration.addNewContactInFrame(estimator.model(),frameLAIndex,calibrationAssumedArmJetContact);

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -2890,13 +2890,17 @@ bool WholeBodyDynamicsDevice::setupCalibrationWithVerticalForcesOnTheFeetAndJets
     // We assume that all the 6 contacts are Pure Forces with Known Directions (1D) at the origin of each frame
     iDynTree::Direction zPosAxis = iDynTree::Direction(0,0,1);
     iDynTree::Direction zNegAxis = iDynTree::Direction(0,0,-1);
-    double p100ThrustN = -2;
-    double p220ThrustN = -9;
-    iDynTree::Force jetArmForce = iDynTree::Force(0,0,p100ThrustN);
+    // Nominal Idle thrust values for JetCat P100 jet models = 2N
+    // The negative sign is for the force direction represented in the Arm Jet frame
+    double p100IdleThrustN = -2;
+    // Nominal Idle thrust values for JetCat P220 jet models = 9N
+    // The negative sign is for the force direction represented in the Back Jet frame
+    double p220IdleThrustN = -9;
+    iDynTree::Force jetArmForce = iDynTree::Force(0,0,p100IdleThrustN);
     iDynTree::Torque jetArmTorque = iDynTree::Torque(0,0,0);
     iDynTree::Wrench jetArmWrench = iDynTree::Wrench(jetArmForce, jetArmTorque);
 
-    iDynTree::Force jetBackForce = iDynTree::Force(0,0,p220ThrustN);
+    iDynTree::Force jetBackForce = iDynTree::Force(0,0,p220IdleThrustN);
     iDynTree::Torque jetBackTorque = iDynTree::Torque(0,0,0);
     iDynTree::Wrench jetBackWrench = iDynTree::Wrench(jetBackForce, jetBackTorque);
 

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -460,6 +460,18 @@ private:
      virtual bool calibStanding(const std::string& calib_code, const int32_t nr_of_samples = 100);
 
      /**
+      * Calibrate the force/torque sensors when on double support and with jet engines turned ON and on idle thrust
+      * (WARNING: works only with iRonCub-Mk1).
+      * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the sole).
+      * For this calibration the strong assumption of simmetry of the robot and its pose is done. Also, only pure forces are
+      * assumed to be acting on the soles
+      * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
+      * @param nr_of_samples number of samples
+      * @return true/false on success/failure
+      */
+     virtual bool calibStandingWithJetsiRonCubMk1(const std::string& calib_code, const int32_t nr_of_samples = 100);
+
+     /**
       * Calibrate the force/torque sensors when on single support on left foot
       * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the left sole).
       * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
@@ -590,6 +602,7 @@ private:
     void setupCalibrationCommonPart(const int32_t nrOfSamples);
     bool setupCalibrationWithExternalWrenchOnOneFrame(const std::string & frameName, const int32_t nrOfSamples);
     bool setupCalibrationWithExternalWrenchesOnTwoFrames(const std::string & frame1Name, const std::string & frame2Name, const int32_t nrOfSamples);
+    bool setupCalibrationWithVerticalForcesOnTheFeetAndJetsONiRonCubMk1(const int32_t nrOfSamples);
 
      /**
       * RPC Calibration related attributes

--- a/idl/wholeBodyDynamics_IDLServer/autogenerated/include/wholeBodyDynamics_IDLServer.h
+++ b/idl/wholeBodyDynamics_IDLServer/autogenerated/include/wholeBodyDynamics_IDLServer.h
@@ -40,12 +40,24 @@ public:
     /**
      * Calibrate the force/torque sensors when on double support
      * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the sole).
-     * For this calibration the strong assumption of simmetry of the robot and its pose is done.
+     * For this calibration the strong assumption of symmetry of the robot and its pose is done.
      * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
      * @param nr_of_samples number of samples
      * @return true/false on success/failure
      */
     virtual bool calibStanding(const std::string& calib_code, const std::int32_t nr_of_samples = 100);
+
+    /**
+     * Calibrate the force/torque sensors when on double support and with jet engines turned ON and on idle thrust
+     * (WARNING: works only with iRonCub-Mk1).
+     * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the sole).
+     * For this calibration the strong assumption of symmetry of the robot and its pose is done. Also, only pure forces are
+     * assumed to be acting on the soles
+     * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
+     * @param nr_of_samples number of samples
+     * @return true/false on success/failure
+     */
+    virtual bool calibStandingWithJetsiRonCubMk1(const std::string& calib_code, const std::int32_t nr_of_samples = 100);
 
     /**
      * Calibrate the force/torque sensors when on single support on left foot

--- a/idl/wholeBodyDynamics_IDLServer/wholeBodyDynamics_IDLServer.thrift
+++ b/idl/wholeBodyDynamics_IDLServer/wholeBodyDynamics_IDLServer.thrift
@@ -20,12 +20,24 @@ service wholeBodyDynamics_IDLServer
   /**
   * Calibrate the force/torque sensors when on double support
   * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the sole).
-  * For this calibration the strong assumption of simmetry of the robot and its pose is done.
+  * For this calibration the strong assumption of symmetry of the robot and its pose is done.
   * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
   * @param nr_of_samples number of samples
   * @return true/false on success/failure
   */
   bool calibStanding(1:string calib_code, 2:i32 nr_of_samples=100)
+
+  /**
+  * Calibrate the force/torque sensors when on double support and with jet engines turned ON and on idle thrust
+  * (WARNING: works only with iRonCub-Mk1).
+  * (WARNING: calibrate the sensors when the only external forces acting on the robot are on the sole).
+  * For this calibration the strong assumption of symmetry of the robot and its pose is done. Also, only pure forces are
+  * assumed to be acting on the soles
+  * @param calib_code argument to specify the sensors to calibrate (all,arms,legs,feet)
+  * @param nr_of_samples number of samples
+  * @return true/false on success/failure
+  */
+  bool calibStandingWithJetsiRonCubMk1(1:string calib_code, 2:i32 nr_of_samples=100)
 
  /**
   * Calibrate the force/torque sensors when on single support on left foot


### PR DESCRIPTION
Reference issue https://github.com/dic-iit/element_ironcub-estimation/issues/93

This PR adds another `yarp rpc` fucntion `calibStandingWithJetsiRonCubMk1`, to be used only with `iRonCub-Mk1` model/robot.

- The function is intended to be used when the jets in `iRonCub-Mk1` are ON with idle thrust value.
- The function is similar to `calibStanding` with an addition of other 4 known-wrench contacts. 