### PR TITLE
Add INTERNAL flag to devices cmake to support proper compilation when some cmake flags are unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Always enable compilation of devices (See [!115](https://github.com/robotology/whole-body-estimators/pull/115))
 
 ## [0.5.0] - 2021-05-14
 ### Added

--- a/devices/baseEstimatorV1/CMakeLists.txt
+++ b/devices/baseEstimatorV1/CMakeLists.txt
@@ -28,7 +28,7 @@ set(FBE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/baseEstimatorV1.cpp
 yarp_prepare_plugin(baseEstimatorV1 CATEGORY device
                     TYPE yarp::dev::baseEstimatorV1
                     INCLUDE ${FBE_HEADERS}
-                    DEFAULT ON)
+                    INTERNAL)
 
 yarp_add_idl(THRIFT "${CMAKE_CURRENT_SOURCE_DIR}/thrifts/floatingBaseEstimationRPC.thrift")
 add_library(floatingBaseEstimationRPC-service STATIC ${THRIFT})

--- a/devices/genericSensorClient/CMakeLists.txt
+++ b/devices/genericSensorClient/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(YARP REQUIRED)
 yarp_prepare_plugin(genericSensorClient CATEGORY device
                                         TYPE yarp::dev::GenericSensorClient
                                         INCLUDE "GenericSensorClient.h"
-                                        DEFAULT ON
+                                        INTERNAL
                                         ADVANCED)
 
 if(ENABLE_genericSensorClient)

--- a/devices/virtualAnalogClient/CMakeLists.txt
+++ b/devices/virtualAnalogClient/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(YARP REQUIRED)
 yarp_prepare_plugin(virtualAnalogClient CATEGORY device
                                         TYPE yarp::dev::VirtualAnalogClient
                                         INCLUDE "VirtualAnalogClient.h"
-                                        DEFAULT ON
+                                        INTERNAL
                                         ADVANCED)
 
 if(ENABLE_virtualAnalogClient)

--- a/devices/virtualAnalogRemapper/CMakeLists.txt
+++ b/devices/virtualAnalogRemapper/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(YARP REQUIRED)
 yarp_prepare_plugin(virtualAnalogRemapper CATEGORY device
                                           TYPE yarp::dev::VirtualAnalogRemapper
                                           INCLUDE "VirtualAnalogRemapper.h"
-                                          DEFAULT ON
+                                          INTERNAL
                                           ADVANCED)
 
 if(ENABLE_virtualAnalogRemapper)

--- a/devices/wholeBodyDynamics/CMakeLists.txt
+++ b/devices/wholeBodyDynamics/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(iDynTree REQUIRED)
 yarp_prepare_plugin(wholebodydynamics CATEGORY device
                                       TYPE yarp::dev::WholeBodyDynamicsDevice
                                       INCLUDE "WholeBodyDynamicsDevice.h"
-                                      DEFAULT ON
+                                      INTERNAL
                                       ADVANCED)
 
 if(ENABLE_wholebodydynamics)


### PR DESCRIPTION
See https://github.com/robotology/yarp/issues/2606