### PR TITLE
Fix deprecation with iDynTree 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
     YCM_TAG: v0.11.1
     YARP_TAG: v3.3.2
     ICUB_TAG: v1.15.0
-    iDynTree_TAG: v1.1.0   
+    iDynTree_TAG: v3.0.0   
     # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by Github Actions to point to our vcpkg
     VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.1] - 2021-07-12
+### Fixed
+- Fixed compilation with iDynTree 4 (https://github.com/robotology/whole-body-estimators/pull/116).
+
 ## [0.5.0] - 2021-05-14
 ### Added
 - Added a `yarp rpc` command `calibStandingWithJetsiRonCubMk1` that performs `calibStanding` for `iRonCub-Mk1` model/robot when the jets are ON and on `idle` thrust. (See [!113](https://github.com/robotology/whole-body-estimators/pull/113)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
 ## [0.5.1] - 2021-07-12
 ### Fixed
 - Fixed compilation with iDynTree 4 (https://github.com/robotology/whole-body-estimators/pull/116).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 project(whole-body-estimators LANGUAGES CXX
-                              VERSION 0.2)
+                              VERSION 0.5.1)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -621,7 +621,7 @@ namespace yarp {
         yarp::sig::Vector m_world_velocity_base_from_imu;
 
         std::string m_left_foot_ft_sensor{"l_foot_ft_sensor"};
-        unsigned int m_left_foot_ft_sensor_index, m_right_foot_ft_sensor_index;
+        std::ptrdiff_t m_left_foot_ft_sensor_index, m_right_foot_ft_sensor_index;
         std::string m_right_foot_ft_sensor{"r_foot_ft_sensor"};
         std::string m_right_sole{"r_sole"};
         std::string m_left_sole{"l_sole"};


### PR DESCRIPTION
In https://github.com/robotology/idyntree/pull/770 the `getSensorIndex` variant that takes `std::ptrdiff_t` was deprecated, and it has been removed in the upcoming iDynTree 4 (https://github.com/robotology/idyntree/pull/884). This PR fixes the deprecation warning in iDynTree 3 and the compilation with iDynTree 4.

I also bumped the version of iDynTree used in CI that it was quite old, and prevented the CI to compile correctly this PR.