### PR TITLE
Fix compilation against YARP 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.6.1] - 2021-12-24
+
+### Fixed
+- Fixed compilation against YARP 3.6 (https://github.com/robotology/whole-body-estimators/pull/135).
+
 ## [0.6.0] - 2021-12-03
 ### Added
 - Add a parameter to set the periodicity of the WholeBodyDynamics thread (See [!130](https://github.com/robotology/whole-body-estimators/pull/130)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.6.1] - 2021-12-24
+## [0.6.1] - 2021-01-03
 
 ### Fixed
 - Fixed compilation against YARP 3.6 (https://github.com/robotology/whole-body-estimators/pull/135).

--- a/idl/wholeBodyDynamicsSettings/wholeBodyDynamicsSettings.thrift
+++ b/idl/wholeBodyDynamicsSettings/wholeBodyDynamicsSettings.thrift
@@ -29,4 +29,6 @@ struct wholeBodyDynamicsSettings {
     11: bool startWithZeroFTSensorOffsets   /** Use zero FT sensor offsets at startup. If this flag is set to false, the device estimates the offsets of FT sensors at startup. Note that this option allows to enable/disable skipping the manual calling of resetOffsets to reset the offsets for FT sensors, most specially during simulations*/
     /** If this flag is set to true, the read from the sensors is skipped at startup */
     12: bool disableSensorReadCheckAtStartup
-}
+} (
+    yarp.editor = "true"
+)


### PR DESCRIPTION
In YARP 3.6, the Editor internal structure for thrift data structures is now not generated by default. So to fix compilation, we now enable it.

Fix https://github.com/robotology/whole-body-estimators/issues/134 .