### PR TITLE
Attempt to improve the performances of the ctrlLibRT library

### DIFF
--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -2203,7 +2203,7 @@ void WholeBodyDynamicsDevice::filterSensorsAndRemoveSensorOffsets()
 
         // Run the filter
         Eigen::Ref<const Eigen::VectorXd> outputFt = filters.forcetorqueFilters[ft]->filt(filters.bufferEigen6);
-        iDynTree::toEigen(filteredFTMeasure.getLinearVec3()) = outputFt.tail<3>();
+        iDynTree::toEigen(filteredFTMeasure.getLinearVec3()) = outputFt.head<3>();
         iDynTree::toEigen(filteredFTMeasure.getAngularVec3()) = outputFt.tail<3>();
 
         filteredSensorMeasurements.setMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,filteredFTMeasure);

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -2188,22 +2188,23 @@ void WholeBodyDynamicsDevice::filterSensorsAndRemoveSensorOffsets()
                                   settings.jointAccFilterCutoffInHz);
 
     // Filter and remove offset fromn F/T sensors
+    iDynTree::Wrench rawFTMeasure;
+    iDynTree::Wrench rawFTMeasureWithOffsetRemoved;
+    iDynTree::Wrench filteredFTMeasure;
     for(size_t ft=0; ft < estimator.sensors().getNrOfSensors(iDynTree::SIX_AXIS_FORCE_TORQUE); ft++ )
     {
-        iDynTree::Wrench rawFTMeasure;
         rawSensorsMeasurements.getMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,rawFTMeasure);
 
-        iDynTree::Wrench rawFTMeasureWithOffsetRemoved  = ftProcessors[ft].filt(rawFTMeasure,tempMeasurements[ft]);
+        rawFTMeasureWithOffsetRemoved = ftProcessors[ft].filt(rawFTMeasure,tempMeasurements[ft]);
 
-        // Filter the data
-        iDynTree::toYarp(rawFTMeasureWithOffsetRemoved,filters.bufferYarp6);
+        // // Filter the data
+        filters.bufferEigen6.head<3>() = iDynTree::toEigen(rawFTMeasureWithOffsetRemoved.getLinearVec3());
+        filters.bufferEigen6.tail<3>() = iDynTree::toEigen(rawFTMeasureWithOffsetRemoved.getAngularVec3());
 
         // Run the filter
-        const yarp::sig::Vector & outputFt = filters.forcetorqueFilters[ft]->filt(filters.bufferYarp6);
-
-        iDynTree::Wrench filteredFTMeasure;
-
-        iDynTree::toiDynTree(outputFt,filteredFTMeasure);
+        Eigen::Ref<const Eigen::VectorXd> outputFt = filters.forcetorqueFilters[ft]->filt(filters.bufferEigen6);
+        iDynTree::toEigen(filteredFTMeasure.getLinearVec3()) = outputFt.tail<3>();
+        iDynTree::toEigen(filteredFTMeasure.getAngularVec3()) = outputFt.tail<3>();
 
         filteredSensorMeasurements.setMeasurement(iDynTree::SIX_AXIS_FORCE_TORQUE,ft,filteredFTMeasure);
     }
@@ -2254,37 +2255,20 @@ void WholeBodyDynamicsDevice::filterSensorsAndRemoveSensorOffsets()
     // Filter joint vel
     if( settings.useJointVelocity )
     {
-        iDynTree::toYarp(jointVel,filters.bufferYarpDofs);
-
-        const yarp::sig::Vector & outputJointVel = filters.jntVelFilter->filt(filters.bufferYarpDofs);
-
-        iDynTree::toiDynTree(outputJointVel,jointVel);
+        iDynTree::toEigen(jointVel) = filters.jntVelFilter->filt(iDynTree::toEigen(jointVel));
     }
 
     // Filter joint acc
     if( settings.useJointAcceleration )
     {
-        iDynTree::toYarp(jointAcc,filters.bufferYarpDofs);
-
-        const yarp::sig::Vector & outputJointAcc = filters.jntAccFilter->filt(filters.bufferYarpDofs);
-
-        iDynTree::toiDynTree(outputJointAcc,jointAcc);
+        iDynTree::toEigen(jointAcc) = filters.jntAccFilter->filt(iDynTree::toEigen(jointAcc));
     }
 
     // Filter IMU Sensor
     if( settings.kinematicSource == IMU )
     {
-        iDynTree::toYarp(rawIMUMeasurements.linProperAcc,filters.bufferYarp3);
-
-        const yarp::sig::Vector & outputLinAcc = filters.imuLinearAccelerationFilter->filt(filters.bufferYarp3);
-
-        iDynTree::toiDynTree(outputLinAcc,filteredIMUMeasurements.linProperAcc);
-
-        iDynTree::toYarp(rawIMUMeasurements.angularVel,filters.bufferYarp3);
-
-        const yarp::sig::Vector & outputAngVel = filters.imuAngularVelocityFilter->filt(filters.bufferYarp3);
-
-        iDynTree::toiDynTree(outputAngVel,filteredIMUMeasurements.angularVel);
+        iDynTree::toEigen(filteredIMUMeasurements.linProperAcc) = filters.imuLinearAccelerationFilter->filt(iDynTree::toEigen(rawIMUMeasurements.linProperAcc));
+        iDynTree::toEigen(filteredIMUMeasurements.angularVel) = filters.imuAngularVelocityFilter->filt(iDynTree::toEigen(rawIMUMeasurements.angularVel));
 
         // For now we just assume that the angular acceleration is zero
         filteredIMUMeasurements.angularAcc.zero();
@@ -3430,10 +3414,7 @@ wholeBodyDynamicsDeviceFilters::wholeBodyDynamicsDeviceFilters(): imuLinearAccel
                                                                   forcetorqueFilters(0),
                                                                   jntVelFilter(0),
                                                                   jntAccFilter(0),
-                                                                  jntVelAccKFFilter(nullptr),
-                                                                  bufferYarp3(0),
-                                                                  bufferYarp6(0),
-                                                                  bufferYarpDofs(0)
+                                                                  jntVelAccKFFilter(nullptr)
 {
 
 }
@@ -3551,26 +3532,24 @@ void wholeBodyDynamicsDeviceFilters::init(int nrOfFTSensors,
                                           double periodInSeconds)
 {
     // Allocate buffers
-    bufferYarp3.resize(3,0.0);
-    bufferYarp6.resize(6,0.0);
-    bufferYarpDofs.resize(nrOfDOFsProcessed,0.0);
+    const Eigen::VectorXd dofsDummy = Eigen::VectorXd::Zero(nrOfDOFsProcessed);
 
     imuLinearAccelerationFilter =
-        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForIMUInHz,periodInSeconds,bufferYarp3);
+        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForIMUInHz,periodInSeconds,Eigen::Vector3d::Zero());
     imuAngularVelocityFilter =
-        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForIMUInHz,periodInSeconds,bufferYarp3);
+        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForIMUInHz,periodInSeconds,Eigen::Vector3d::Zero());
 
     forcetorqueFilters.resize(nrOfFTSensors);
     for(int ft_numeric = 0; ft_numeric < nrOfFTSensors; ft_numeric++ )
     {
         forcetorqueFilters[ft_numeric] =
-                new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForFTInHz,periodInSeconds,bufferYarp6);
+            new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForFTInHz,periodInSeconds,Eigen::Matrix<double,6,1>::Zero());
     }
 
     jntVelFilter =
-        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForJointVelInHz,periodInSeconds,bufferYarpDofs);
+        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForJointVelInHz,periodInSeconds,dofsDummy);
     jntAccFilter =
-        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForJointAccInHz,periodInSeconds,bufferYarpDofs);
+        new iCub::ctrl::realTime::FirstOrderLowPassFilter(initialCutOffForJointAccInHz,periodInSeconds,dofsDummy);
 }
 
 

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -112,14 +112,8 @@ class wholeBodyDynamicsDeviceFilters
     ///< KF filter for Joint velocity and accelerations
     std::unique_ptr<iDynTree::DiscreteKalmanFilterHelper> jntVelAccKFFilter;
 
-    ///< Yarp vector buffer of dimension 3
-    yarp::sig::Vector bufferYarp3;
-
-    ///< Yarp vector buffer of dimension 6
-    yarp::sig::Vector bufferYarp6;
-
-    ///< Yarp vector buffer of dimension dofs
-    yarp::sig::Vector bufferYarpDofs;
+    ///< Eigen vector buffer of dimension 6
+    Eigen::Matrix<double, 6, 1> bufferEigen6;
 };
 
 /**

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -112,7 +112,7 @@ class wholeBodyDynamicsDeviceFilters
     ///< KF filter for Joint velocity and accelerations
     std::unique_ptr<iDynTree::DiscreteKalmanFilterHelper> jntVelAccKFFilter;
 
-    ///< Eigen vector buffer of dimension 6
+    ///< Temporary Eigen vector buffer of dimension 6
     Eigen::Matrix<double, 6, 1> bufferEigen6;
 };
 

--- a/libraries/ctrlLibRT/CMakeLists.txt
+++ b/libraries/ctrlLibRT/CMakeLists.txt
@@ -21,7 +21,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 target_include_directories(${PROJECT_NAME} PUBLIC  ${EIGEN3_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME} ${YARP_LIBRARIES})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY PUBLIC_HEADER ${${PROJECT_NAME}_HELPERS_SRCS})
 

--- a/libraries/ctrlLibRT/src/filters.cpp
+++ b/libraries/ctrlLibRT/src/filters.cpp
@@ -18,29 +18,18 @@
 
 #include "ctrlLibRT/filters.h"
 
-#include <yarp/math/Math.h>
+#include <memory>
 
 using namespace std;
-using namespace yarp::sig;
-using namespace yarp::math;
 using namespace iCub::ctrl::realTime;
 
 /***************************************************************************/
-Eigen::Map<Eigen::VectorXd> toEigen(yarp::sig::Vector & vec)
+Filter::Filter(const Eigen::Ref<const Eigen::VectorXd>& num,
+               const Eigen::Ref<const Eigen::VectorXd>& den,
+               const Eigen::Ref<const Eigen::VectorXd>& y0)
 {
-    return Eigen::Map<Eigen::VectorXd>(vec.data(),vec.size());
-}
-
-Eigen::Map<const Eigen::VectorXd> toEigen(const yarp::sig::Vector & vec)
-{
-    return Eigen::Map<const Eigen::VectorXd>(vec.data(),vec.size());
-}
-
-/***************************************************************************/
-Filter::Filter(const Vector &num, const Vector &den, const Vector &y0)
-{
-    b=toEigen(num);
-    a=toEigen(den);
+    b = num;
+    a = den;
 
     m=b.size(); uold.resize(y0.size(),m-1);
     n=a.size(); yold.resize(y0.size(),m-1);
@@ -50,64 +39,60 @@ Filter::Filter(const Vector &num, const Vector &den, const Vector &y0)
 
 
 /***************************************************************************/
-void Filter::init(const Vector &y0)
+void Filter::init(const Eigen::Ref<const Eigen::VectorXd>& y0)
 {
     // otherwise use zero
-        init(y0,yarp::math::zeros(y0.length()));
+    init(y0, Eigen::VectorXd::Zero(y0.size()));
 }
 
 
 /***************************************************************************/
-void Filter::init(const Vector &y0, const Vector &u0)
+void Filter::init(const Eigen::Ref<const Eigen::VectorXd>& y0,
+                  const Eigen::Ref<const Eigen::VectorXd>& u0)
 {
-    Vector u_init(y0.length(),0.0);
-    Vector y_init=y0;
+    // set all the element of u_init equal to zero
+    Eigen::VectorXd u_init = Eigen::VectorXd::Zero(y0.size());
+    Eigen::VectorXd y_init = y0;
     y=y0;
 
-    double sum_b=0.0;
-    for (int i=0; i<b.size(); i++)
-        sum_b+=b[i];
+    const double sum_b = b.sum();
+    const double sum_a = a.sum();
 
-    double sum_a=0.0;
-    for (int i=0; i<a.size(); i++)
-        sum_a+=a[i];
-
-    if (fabs(sum_b)>1e-9)   // if filter DC gain is not zero
-        u_init=(sum_a/sum_b)*y0;
+    if (abs(sum_b) > 1e-9) // if filter DC gain is not zero
+        u_init = (sum_a / sum_b) * y0;
     else
     {
         // if filter gain is zero then you need to know in advance what
         // the next input is going to be for initializing (that is u0)
         // Note that, unless y0=0, the filter output is not going to be stable
-        u_init=u0;
-        if (fabs(sum_a-a[0])>1e-9)
-            y_init=a[0]/(a[0]-sum_a)*y;
+        u_init = u0;
+        if (abs(sum_a - a[0]) > 1e-9)
+            y_init = a[0] / (a[0] - sum_a) * y;
         // if sum_a==a[0] then the filter can only be initialized to zero
     }
 
-    for (int i=0; i<yold.cols(); i++)
-        yold.col(i)=toEigen(y_init);
+    for (int i = 0; i < yold.cols(); i++)
+        yold.col(i) = y_init;
     yold_last_column_sample = 0;
 
-    for (int i=0; i<uold.cols(); i++)
-        uold.col(i)=toEigen(u_init);
+    for (int i = 0; i < uold.cols(); i++)
+        uold.col(i) = u_init;
     uold_last_column_sample = 0;
 }
 
-
 /***************************************************************************/
-void Filter::getCoeffs(Vector &num, Vector &den)
+void Filter::getCoeffs(Eigen::Ref<Eigen::VectorXd> num, Eigen::Ref<Eigen::VectorXd> den)
 {
-    toEigen(num)=b;
-    toEigen(den)=a;
+    num = b;
+    den = a;
 }
 
-
 /***************************************************************************/
-void Filter::setCoeffs(const Vector &num, const Vector &den)
+void Filter::setCoeffs(const Eigen::Ref<const Eigen::VectorXd>& num,
+                       const Eigen::Ref<const Eigen::VectorXd>& den)
 {
-    b=toEigen(num);
-    a=toEigen(den);
+    b = num;
+    a = den;
 
     uold.setZero();
     yold.setZero();
@@ -120,44 +105,44 @@ void Filter::setCoeffs(const Vector &num, const Vector &den)
 
 
 /***************************************************************************/
-bool Filter::adjustCoeffs(const Vector &num, const Vector &den)
+bool Filter::adjustCoeffs(const Eigen::Ref<const Eigen::VectorXd>& num,
+                          const Eigen::Ref<const Eigen::VectorXd>& den)
 {
-    if ((num.length()==(size_t)b.size()) && (den.length()==(size_t)a.size()))
+    if ((num.size()==(size_t)b.size()) && (den.size()==(size_t)a.size()))
     {
-        (b)=toEigen(num);
-        (a)=toEigen(den);
+        b = num;
+        a = den;
 
         return true;
-    }
-    else
+    } else
         return false;
 }
 
 
 /***************************************************************************/
-const Vector & Filter::filt(const Vector &u)
+Eigen::Ref<const Eigen::VectorXd> Filter::filt(const Eigen::Ref<const Eigen::VectorXd>& u)
 {
-    toEigen(y)=b[0]*toEigen(u);
+    y = b[0] * u;
 
     for (size_t i=1; i<m; i++)
     {
-        toEigen(y)+=b[i]*uold.col((m-i+uold_last_column_sample)%(m-1));
+        y.noalias() += b[i] * uold.col((m - i + uold_last_column_sample) % (m - 1));
     }
 
     for (size_t i=1; i<n; i++)
     {
-        toEigen(y)-=a[i]*yold.col((n-i+yold_last_column_sample)%(n-1));
+        y.noalias() -= a[i] * yold.col((n - i + yold_last_column_sample) % (n - 1));
     }
 
-    toEigen(y)=(1.0/a[0])*toEigen(y);
+    y = (1.0 / a[0]) * y;
 
     uold_last_column_sample++;
-    uold_last_column_sample = uold_last_column_sample%uold.cols();
-    uold.col(uold_last_column_sample) = toEigen(u);
+    uold_last_column_sample = uold_last_column_sample % uold.cols();
+    uold.col(uold_last_column_sample) = u;
 
     yold_last_column_sample++;
-    yold_last_column_sample = yold_last_column_sample%yold.cols();
-    yold.col(yold_last_column_sample) = toEigen(y);
+    yold_last_column_sample = yold_last_column_sample % yold.cols();
+    yold.col(yold_last_column_sample) = y;
 
     return y;
 }
@@ -166,84 +151,73 @@ const Vector & Filter::filt(const Vector &u)
 /**********************************************************************/
 FirstOrderLowPassFilter::FirstOrderLowPassFilter(const double cutFrequency,
                                                  const double sampleTime,
-                                                 const Vector &y0)
+                                                 const Eigen::Ref<const Eigen::VectorXd> &y0)
 {
     fc=cutFrequency;
     Ts=sampleTime;
     y=y0;
-    filter=NULL;
     computeCoeff();
 }
 
-
-/**********************************************************************/
-FirstOrderLowPassFilter::~FirstOrderLowPassFilter()
-{
-    delete filter;
-}
-
-
 /***************************************************************************/
-void FirstOrderLowPassFilter::init(const Vector &y0)
+void FirstOrderLowPassFilter::init(const Eigen::Ref<const Eigen::VectorXd> &y0)
 {
-    if (filter!=NULL)
+    if (filter != nullptr)
         filter->init(y0);
 }
-
 
 /**********************************************************************/
 bool FirstOrderLowPassFilter::setCutFrequency(const double cutFrequency)
 {
-    if (cutFrequency<=0.0)
+    if (cutFrequency <= 0.0)
         return false;
 
     // Optimization : if the  cutoff frequency is exactly the same
     // do not update the coeffiencts
     // Note: in general the equality between two doubles is not a
     // reliable check, but in this case it make sense
-    if( fc != cutFrequency )
+    if (fc != cutFrequency)
     {
-        fc=cutFrequency;
+        fc = cutFrequency;
         computeCoeff();
     }
 
     return true;
 }
 
-
 /**********************************************************************/
 bool FirstOrderLowPassFilter::setSampleTime(const double sampleTime)
 {
-    if (sampleTime<=0.0)
+    if (sampleTime <= 0.0)
         return false;
 
-    Ts=sampleTime;
+    Ts = sampleTime;
     computeCoeff();
 
     return true;
 }
 
-
 /**********************************************************************/
-const Vector& FirstOrderLowPassFilter::filt(const Vector &u)
+Eigen::Ref<const Eigen::VectorXd>
+FirstOrderLowPassFilter::filt(const Eigen::Ref<const Eigen::VectorXd>& u)
 {
-    if (filter!=NULL)
-        y=filter->filt(u);
+    if (filter != nullptr)
+        y = filter->filt(u);
 
     return y;
 }
 
-
 /**********************************************************************/
 void FirstOrderLowPassFilter::computeCoeff()
 {
-    double tau=1.0/(2.0*M_PI*fc);
-    Vector num=cat(Ts,Ts);
-    Vector den=cat(2.0*tau+Ts,Ts-2.0*tau);
+    const double tau = 1.0 / (2.0 * M_PI * fc);
+    const Eigen::Vector2d num = Eigen::Vector2d::Constant(Ts);
+    Eigen::Vector2d den;
+    den << 2.0 * tau + Ts, Ts - 2.0 * tau;
 
-    if (filter!=NULL)
+    if (filter!=nullptr)
         filter->adjustCoeffs(num,den);
     else
-        filter=new Filter(num,den,y);
+        filter = std::make_unique<Filter>(num, den, y);
 }
 


### PR DESCRIPTION
As a consequence of #141 I tried to improve the performances of the `ctrlLibRT`. Before explaining what I did I would recall that:
⚠️ **we should test this PR on the robot to understand if the performances are improved**

First of all, I tried to remove the copies from yarp to idyntree, thanks to this choice this code
```cpp
iDynTree::toYarp(jointAcc,filters.bufferYarpDofs);
const yarp::sig::Vector & outputJointAcc = filters.jntAccFilter->filt(filters.bufferYarpDofs);
iDynTree::toiDynTree(outputJointAcc,jointAcc);
```
becomes
```cpp
iDynTree::toEigen(jointAcc) = filters.jntAccFilter->filt(iDynTree::toEigen(jointAcc));
```
so I removed two copies every time the joint state is filtered. A similar approach has been used for joint vel, joint acc, accelerometers and gyros, ft.

To achieve that I changed the interface of the `ctrLibRT` to consider `eigen::ref`

