### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2019, macos-latest]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
`windows-latest` now contains Visual Studio 2022, so to use Visual Studio 2019 let's use `windows-2019`.