### PR TITLE
Switch default carrier of `genericSensorClient` device from `udp` to `fast_tcp` to avoid delays up to 0.25 seconds when a receiver is interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the `yarp rpc` command `calibStandingWithJetsiRonCubMk1` to be `calibStandingWithJetsiRonCub`, in order to perform `calibStanding` for the models `iRonCub-Mk1` and `iRonCub-Mk1_1` (See [!136](https://github.com/robotology/whole-body-estimators/pull/136)).
+- Switched default carrier of `genericSensorClient` device from `udp` to `fast_tcp` to avoid delays up to 0.25 seconds when a receiver is interrupted ().
 
 ## [0.6.1] - 2021-01-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the `yarp rpc` command `calibStandingWithJetsiRonCubMk1` to be `calibStandingWithJetsiRonCub`, in order to perform `calibStanding` for the models `iRonCub-Mk1` and `iRonCub-Mk1_1` (See [!136](https://github.com/robotology/whole-body-estimators/pull/136)).
-- Switched default carrier of `genericSensorClient` device from `udp` to `fast_tcp` to avoid delays up to 0.25 seconds when a receiver is interrupted ().
+- Switched default carrier of `genericSensorClient` device from `udp` to `fast_tcp` to avoid delays up to 0.25 seconds when a receiver is interrupted (https://github.com/robotology/whole-body-estimators/pull/145).
 
 ## [0.6.1] - 2021-01-03
 

--- a/devices/genericSensorClient/GenericSensorClient.cpp
+++ b/devices/genericSensorClient/GenericSensorClient.cpp
@@ -132,7 +132,7 @@ int GSInputPortProcessor::getChannels()
 
 bool yarp::dev::GenericSensorClient::open(yarp::os::Searchable &config)
 {
-    std::string carrier = config.check("carrier", Value("udp"), "default carrier for streaming robot state").asString().c_str();
+    std::string carrier = config.check("carrier", Value("fast_tcp"), "default carrier for streaming robot state").asString().c_str();
 
     local.clear();
     remote.clear();

--- a/devices/genericSensorClient/GenericSensorClient.h
+++ b/devices/genericSensorClient/GenericSensorClient.h
@@ -76,7 +76,7 @@ namespace dev {
 * |:--------------:|:------:|:-----:|:-------------:|:--------: |:-------------:|:-----:|
 * | local          | string |       |               | Yes       | full name if the port opened by the device  | must start with a '/' character |
 * | remote         | string |       |               | Yes       | full name of the port the device need to connect to | must start with a '/' character |
-* | carrier        | string |       | udp           | No        | type of carrier to use, like tcp, udp and so on ...  | - |
+* | carrier        | string |       | fast_tcp      | No        | type of carrier to use, like fast_tcp, tcp, udp and so on ...  | - |
 *
 *  The device will create a port with name <local> and will connect to a port colled <remote> at startup,
 * ex: <b> /myModule/linertial </b>, and will connect to a port called <b> /icub/inertial<b>.


### PR DESCRIPTION
Switch the default carrier for two reasons (both detailed in https://github.com/robotology/yarp/issues/2814#issuecomment-1064943035):
* YARP blocks for 0.25 seconds whenever a UDP receiver is interrupted. The reason of this delay is not clear, but it will not be changed as the effect of such change are unknown due to [Hyrum's Law](https://www.hyrumslaw.com/)
* In general it is not recommended to use a UDP carrier on a stream if there is no other reliable control stream

