### PR TITLE
Fixed the possibility of deadlock in detachAll method in wholebodydynamics and baseEstimatorV1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the `yarp rpc` command `calibStandingWithJetsiRonCubMk1` to be `calibStandingWithJetsiRonCub`, in order to perform `calibStanding` for the models `iRonCub-Mk1` and `iRonCub-Mk1_1` (See [!136](https://github.com/robotology/whole-body-estimators/pull/136)).
 - Switched default carrier of `genericSensorClient` device from `udp` to `fast_tcp` to avoid delays up to 0.25 seconds when a receiver is interrupted (https://github.com/robotology/whole-body-estimators/pull/145).
 
+### Fixed
+- Fixed the possibility of deadlock in detachAll method in `wholebodydynamics` and `baseEstimatorV1`. This deadlock could lead to freeze during closing of the yarprobotinterface or the Gazebo simulator if the `gazebo_yarp_robotinterface` plugin was used.
+
 ## [0.6.1] - 2021-01-03
 
 ### Fixed

--- a/devices/baseEstimatorV1/src/fbeRobotInterface.cpp
+++ b/devices/baseEstimatorV1/src/fbeRobotInterface.cpp
@@ -566,12 +566,12 @@ bool yarp::dev::baseEstimatorV1::loadTransformBroadcaster()
 
 bool yarp::dev::baseEstimatorV1::detachAll()
 {
-    std::lock_guard<std::mutex> guard(m_device_mutex);
-    m_device_initialized_correctly = false;
     if (isRunning())
     {
         stop();
     }
+    std::lock_guard<std::mutex> guard(m_device_mutex);
+    m_device_initialized_correctly = false;
     return true;
 }
 

--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -2849,14 +2849,14 @@ void WholeBodyDynamicsDevice::run()
 
 bool WholeBodyDynamicsDevice::detachAll()
 {
-    std::lock_guard<std::mutex> guard(this->deviceMutex);
-
-    correctlyConfigured = false;
-
     if (isRunning())
     {
         stop();
     }
+
+    std::lock_guard<std::mutex> guard(this->deviceMutex);
+
+    correctlyConfigured = false;
 
     // If gravity compensation was enabled, reset the offsets
     this->resetGravityCompensation();


### PR DESCRIPTION
While debugging https://github.com/robotology/gazebo-yarp-plugins/pull/619#issuecomment-1084910317, I noticed that the `gazebo_yarp_robotinterface` while closing was hanging during this phase:
~~~
[INFO] interrupt1 phase starting...
[INFO] interrupt1 phase finished.
[INFO] shutdown phase starting...
[INFO] Entering action level 2 of phase shutdown
[INFO] Executing detach action, level 2 on device wholebodydynamics with parameters []
~~~

It turns out that indeed there is the possibility of a deadlock. The case is when `detachAll` is called by `thread2`  and [is able to lock the `this->deviceMutex`](https://github.com/robotology/whole-body-estimators/blob/v0.6.1/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp#L2736) when `yarp::os::PeriodicThread` (thread1) already started its loop (i.e. [`step` was called](https://github.com/robotology/yarp/blob/v3.6.0/src/libYARP_os/src/yarp/os/PeriodicThread.cpp#L272)) but the `run` method was not called, i.e. if the execution of thread1  is on a line that goes from https://github.com/robotology/yarp/blob/v3.6.0/src/libYARP_os/src/yarp/os/PeriodicThread.cpp#L226 to https://github.com/robotology/yarp/blob/v3.6.0/src/libYARP_os/src/yarp/os/PeriodicThread.cpp#L246 .

In that case, `thread2` is blocked in [PeriodicThread::stop](https://github.com/robotology/whole-body-estimators/blob/v0.6.1/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp#L2742) (while locking `this->deviceMutex`) as that call contains a call to `join` of `thread1`, but `thread1` was blocked at the beginning of the `run` method (https://github.com/robotology/whole-body-estimators/blob/v0.6.1/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp#L2704) waiting for `this->deviceMutex` to be available, a classical example of deadlock.

A simple way to get rid of the deadlock is just call the stop of a thread before the `this->deviceMutex` is locked.

