### PR TITLE
Implement VirtualAnalogClient::getAxes to fix compilation against YARP 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Implement VirtualAnalogClient::getAxes to fix compilation against YARP 3.8 (https://github.com/robotology/whole-body-estimators/pull/159).
 
 ## [0.9.0] - 2022-08-31
 

--- a/devices/virtualAnalogClient/VirtualAnalogClient.cpp
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.cpp
@@ -239,4 +239,5 @@ virtual bool VirtualAnalogClient::getAxes(int* ax)
     }
 
     *ax = VirtualAnalogClient::getVirtualAnalogSensorChannels();
+    return true;
 }

--- a/devices/virtualAnalogClient/VirtualAnalogClient.cpp
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.cpp
@@ -229,3 +229,14 @@ bool VirtualAnalogClient::getJointType(int axis, JointTypeEnum& type)
     type = m_axisType[axis];
     return true;
 }
+
+virtual bool VirtualAnalogClient::getAxes(int* ax)
+{
+    if( !ax )
+    {
+        yError() << "VirtualAnalogClient: getAxes failed : invalid argument passed";
+        return false;
+    }
+
+    *ax = VirtualAnalogClient::getVirtualAnalogSensorChannels();
+}

--- a/devices/virtualAnalogClient/VirtualAnalogClient.cpp
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.cpp
@@ -230,7 +230,7 @@ bool VirtualAnalogClient::getJointType(int axis, JointTypeEnum& type)
     return true;
 }
 
-virtual bool VirtualAnalogClient::getAxes(int* ax)
+bool VirtualAnalogClient::getAxes(int* ax)
 {
     if( !ax )
     {

--- a/devices/virtualAnalogClient/VirtualAnalogClient.h
+++ b/devices/virtualAnalogClient/VirtualAnalogClient.h
@@ -91,6 +91,7 @@ public:
     /** IAxisInfo methods (documented in IVirtualAnalogSensor class) */
     virtual bool getAxisName(int axis, std::string& name);
     virtual bool getJointType(int axis, yarp::dev::JointTypeEnum& type);
+    virtual bool getAxes(int* ax);
 };
 
 }


### PR DESCRIPTION
Fix https://github.com/robotology/whole-body-estimators/issues/158 .