### PR TITLE
Implement VirtualAnalogRemapper::getAxes to fix compilation with YARP 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- Implement VirtualAnalogClient::getAxes to fix compilation against YARP 3.8 (https://github.com/robotology/whole-body-estimators/pull/159).
+- Implement `VirtualAnalogClient::getAxes` and `VirtualAnalogRemapper::getAxes` to fix compilation against YARP 3.8 (https://github.com/robotology/whole-body-estimators/pull/159, https://github.com/robotology/whole-body-estimators/pull/160).
 
 ## [0.9.0] - 2022-08-31
 

--- a/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
+++ b/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
@@ -346,5 +346,12 @@ bool VirtualAnalogRemapper::getJointType(int axis, JointTypeEnum& type)
 
 bool VirtualAnalogRemapper::getAxes(int* ax)
 {
-    return this->m_axesNames.size();
+    if( !ax )
+    {
+        yError() << "VirtualAnalogRemapper: getAxes failed : invalid argument passed";
+        return false;
+    }
+
+    *ax = this->m_axesNames.size();
+    return true;
 }

--- a/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
+++ b/devices/virtualAnalogRemapper/VirtualAnalogRemapper.cpp
@@ -343,3 +343,8 @@ bool VirtualAnalogRemapper::getJointType(int axis, JointTypeEnum& type)
     }
     return ret;
 }
+
+bool VirtualAnalogRemapper::getAxes(int* ax)
+{
+    return this->m_axesNames.size();
+}

--- a/devices/virtualAnalogRemapper/VirtualAnalogRemapper.h
+++ b/devices/virtualAnalogRemapper/VirtualAnalogRemapper.h
@@ -129,6 +129,7 @@ public:
     /** IAxisInfo methods (documented in IVirtualAnalogSensor class) */
     virtual bool getAxisName(int axis, std::string& name);
     virtual bool getJointType(int axis, yarp::dev::JointTypeEnum& type);
+    virtual bool getAxes(int* ax);
 
     /** IMultipleWrapper methods (documented in IMultipleWrapper */
     virtual bool attachAll(const PolyDriverList &p);


### PR DESCRIPTION
Even after https://github.com/robotology/whole-body-estimators/pull/159, the robotology-superbuild Unstable CI was still failing because there was another method to implement, this PR should finally fix compatibility for the future YARP 3.8 .