### PR TITLE
Change FT sensors names for compatibility with icub-models >= 2.0.0 and robots-configuration >= 2.5.0 (take two)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Change FT sensors names for compatibility with icub-models >= 2.0.0 and robots-configuration >= 2.5.0 (https://github.com/robotology/whole-body-estimators/pull/172).
 
 ### Fixed
 

--- a/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/estimators/fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/estimators/fbe-analogsens.xml
@@ -14,8 +14,8 @@
         <param name="device_period_in_seconds">0.010</param>
         <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll", "l_arm_ft_sensor", "r_arm_ft_sensor", "l_leg_ft_sensor", "r_leg_ft_sensor", "l_foot_ft_sensor", "r_foot_ft_sensor")</param>
         <param name="base_link">root_link</param>
-        <param name="left_foot_ft_sensor">l_foot_ft_sensor</param>
-        <param name="right_foot_ft_sensor">r_foot_ft_sensor</param>
+        <param name="l_foot_ft_sensor">l_foot_ft</param>
+        <param name="r_foot_ft_sensor">r_foot_ft</param>
         <param name="imu_name">head_imu_acc_1x1</param> <!-- options are: "head_imu_acc_1x1" or "root_link_imu_acc" -->
         <param name="head_imu_link">head</param>
         <param name="head_to_base_joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw")</param>
@@ -83,12 +83,12 @@
                 <elem name="head_imu_acc_1x1">inertial</elem>
 <!--                 <elem name="root_link_imu_acc">xsens_inertial</elem> -->
             <!-- f/t sensors -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/launch-fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGazeboV2_5/launch-fbe-analogsens.xml
@@ -33,32 +33,32 @@
     <!-- open FT sens -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_arm/analog:o </param>
-        <param name="local"> /baseestimation/l_arm_ft_sensor </param>
+        <param name="local"> /baseestimation/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_arm/analog:o </param>
-        <param name="local"> /baseestimation/r_arm_ft_sensor </param>
+        <param name="local"> /baseestimation/r_arm_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_leg/analog:o </param>
-        <param name="local"> /baseestimation/l_leg_ft_sensor </param>
+        <param name="local"> /baseestimation/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_leg/analog:o </param>
-        <param name="local"> /baseestimation/r_leg_ft_sensor </param>
+        <param name="local"> /baseestimation/r_leg_ft </param>
     </device>
 
     <device name="left_lower_leg_strain" type="analogsensorclient">
         <param name="remote">/icubSim/left_foot/analog:o</param>
-        <param name="local">/baseestimation/l_foot_ft_sensor:i</param>
+        <param name="local">/baseestimation/l_foot_ft:i</param>
     </device>
 
     <device name="right_lower_leg_strain" type="analogsensorclient">
         <param name="remote">/icubSim/right_foot/analog:o</param>
-        <param name="local">/baseestimation/r_foot_ft_sensor:i</param>
+        <param name="local">/baseestimation/r_foot_ft:i</param>
     </device>
 
     <!-- open transform server -->

--- a/devices/baseEstimatorV1/app/robots/iCubGenova04/estimators/fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGenova04/estimators/fbe-analogsens.xml
@@ -13,8 +13,8 @@
         <param name="device_period_in_seconds">0.010</param>
         <param name="joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_shoulder_yaw", "l_elbow", "r_shoulder_pitch", "r_shoulder_roll", "r_shoulder_yaw", "r_elbow", "l_hip_pitch", "l_hip_roll", "l_hip_yaw", "l_knee", "l_ankle_pitch", "l_ankle_roll", "r_hip_pitch", "r_hip_roll", "r_hip_yaw", "r_knee", "r_ankle_pitch", "r_ankle_roll", "l_arm_ft_sensor", "r_arm_ft_sensor", "l_leg_ft_sensor", "r_leg_ft_sensor", "l_foot_ft_sensor", "r_foot_ft_sensor")</param>
         <param name="base_link">root_link</param>
-        <param name="left_foot_ft_sensor">l_foot_ft_sensor</param>
-        <param name="right_foot_ft_sensor">r_foot_ft_sensor</param>
+        <param name="left_foot_ft">l_foot_ft</param>
+        <param name="right_foot_ft">r_foot_ft</param>
         <param name="imu_name">head_imu_acc_1x1</param> <!-- options are: "head_imu_acc_1x1" or "root_link_imu_acc" -->
         <param name="head_imu_link">head</param>
         <param name="head_to_base_joints_list">("neck_pitch", "neck_roll", "neck_yaw", "torso_pitch", "torso_roll", "torso_yaw")</param>
@@ -83,12 +83,12 @@
                 <elem name="head_imu_acc_1x1">inertial</elem>
 <!--                 <elem name="root_link_imu_acc">xsens_inertial</elem> -->
             <!-- f/t sensors -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/baseEstimatorV1/app/robots/iCubGenova04/launch-fbe-analogsens.xml
+++ b/devices/baseEstimatorV1/app/robots/iCubGenova04/launch-fbe-analogsens.xml
@@ -33,32 +33,32 @@
     <!-- open FT sens -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_arm/analog:o </param>
-        <param name="local"> /baseestimation/l_arm_ft_sensor </param>
+        <param name="local"> /baseestimation/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_arm/analog:o </param>
-        <param name="local"> /baseestimation/r_arm_ft_sensor </param>
+        <param name="local"> /baseestimation/r_arm_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_leg/analog:o </param>
-        <param name="local"> /baseestimation/l_leg_ft_sensor </param>
+        <param name="local"> /baseestimation/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_leg/analog:o </param>
-        <param name="local"> /baseestimation/r_leg_ft_sensor </param>
+        <param name="local"> /baseestimation/r_leg_ft </param>
     </device>
 
     <device name="left_lower_leg_strain" type="analogsensorclient">
         <param name="remote">/icub/left_foot/analog:o</param>
-        <param name="local">/baseestimation/l_foot_ft_sensor:i</param>
+        <param name="local">/baseestimation/l_foot_ft:i</param>
     </device>
 
     <device name="right_lower_leg_strain" type="analogsensorclient">
         <param name="remote">/icub/right_foot/analog:o</param>
-        <param name="local">/baseestimation/r_foot_ft_sensor:i</param>
+        <param name="local">/baseestimation/r_foot_ft:i</param>
     </device>
 
     <!-- open transform server -->

--- a/devices/baseEstimatorV1/include/baseEstimatorV1.h
+++ b/devices/baseEstimatorV1/include/baseEstimatorV1.h
@@ -620,9 +620,9 @@ namespace yarp {
         yarp::sig::Vector m_world_velocity_base; ///< 6D vector velocity of floating base frame in the world reference frame
         yarp::sig::Vector m_world_velocity_base_from_imu;
 
-        std::string m_left_foot_ft_sensor{"l_foot_ft_sensor"};
+        std::string m_left_foot_ft_sensor{"l_foot_ft"};
         std::ptrdiff_t m_left_foot_ft_sensor_index, m_right_foot_ft_sensor_index;
-        std::string m_right_foot_ft_sensor{"r_foot_ft_sensor"};
+        std::string m_right_foot_ft_sensor{"r_foot_ft"};
         std::string m_right_sole{"r_sole"};
         std::string m_left_sole{"l_sole"};
         iDynTree::Rotation m_l_sole_R_l_ft_sensor, m_r_sole_R_r_ft_sensor;

--- a/devices/wholeBodyDynamics/README.md
+++ b/devices/wholeBodyDynamics/README.md
@@ -33,7 +33,7 @@ For an overview on `wholeBodyDynamics` and to understand how to run the device, 
 | contactWrenchPosition |      -   | vector of doubles |  -    |    -          | Yes if 'overrideContactFrames' exists      | It should contain 3 fields for each override frame.  |     |
 | useJointVelocity     |        - | bool              |  -    |      true     |  No      | Select if the measured joint velocities (read from the getEncoderSpeeds method) are used for estimation, or if they should be forced to 0.0 . | The default value of true is deprecated, and in the future the parameter will be required. |
 | useJointAcceleration |        - | bool              |  -    |      true     |  No      | Select if the measured joint accelerations (read from the getEncoderAccelerations method) are used for estimation, or if they should be forced to 0.0 . | The default value of true is deprecated, and in the future the parameter will be required. |
-| streamFilteredFT     |        - | bool              |  -    |      false    |  No      | Select if the filtered and offset removed forces will be streamed or not. The name of the ports have the following syntax:  portname=(portPrefix+"/filteredFT/"+sensorName). Example: "myPrefix/filteredFT/l_leg_ft_sensor" | The value streamed by this ports is affected by the secondary calibration matrix, the estimated offset and temperature coefficients ( if any ). |
+| streamFilteredFT     |        - | bool              |  -    |      false    |  No      | Select if the filtered and offset removed forces will be streamed or not. The name of the ports have the following syntax:  portname=(portPrefix+"/filteredFT/"+sensorName). Example: "myPrefix/filteredFT/l_leg_ft" | The value streamed by this ports is affected by the secondary calibration matrix, the estimated offset and temperature coefficients ( if any ). |
 | publishNetExternalWrenches |        - | bool          |  -    |      false   |  No      | Flag to stream the net external wrenches acting on each link on the port portPrefix+"/netExternalWrenches:o". The content is a bottle of n pairs, where n is the number of links. The first element of each pair is the name of the link. The second element is yet another list of 6 elements containing the value of the net external wrench, defined in the link frame. The first three elements are the linear part, while the other three are the angular part.| |
 | useSkinForContacts     |        - | bool              |  -    |      true    |  No      | Flag to skip using tactile skin sensors for updating contact points and external force (pressure) information | |
 | estimateJointVelocityAcceleration     |        - | bool              |  -    |      false    |  No      | Flag to estimate the joint velocities and accelerations using Kalman filter. If true, the same measurements from the low level are ignored. | |
@@ -86,13 +86,13 @@ Typically this estimates are provided only for the upper joints (arms and torso)
 
   ``` xml
        <group name="FT_SECONDARY_CALIBRATION">
-              <param name="l_arm_ft_sensor">(1.0,0.0,0.0,0.0,0.0,0.0,
+              <param name="l_arm_ft">(1.0,0.0,0.0,0.0,0.0,0.0,
                                              0.0,1.0,0.0,0.0,0.0,0.0,
                                              0.0,0.0,1.0,0.0,0.0,0.0,
                                              0.0,0.0,0.0,1.0,0.0,0.0,
                                              0.0,0.0,0.0,0.0,1.0,0.0,
                                              0.0,0.0,0.0,0.0,0.0,1.0)                   </param>
-              <param name="r_arm_ft_sensor">(1.0,0.0,0.0,0.0,0.0,0.0,
+              <param name="r_arm_ft">(1.0,0.0,0.0,0.0,0.0,0.0,
                                              0.0,1.0,0.0,0.0,0.0,0.0,
                                              0.0,0.0,1.0,0.0,0.0,0.0,
                                              0.0,0.0,0.0,0.001,0.0,0.0,
@@ -121,8 +121,8 @@ Typically this estimates are provided only for the upper joints (arms and torso)
   Example of part of a configuration file using `.xml` `yarprobotinterface` format (remember to put the fractional dot!).
   ``` xml
        <group name="FT_TEMPERATURE_COEFFICIENTS">
-              <param name="l_arm_ft_sensor">(0.0,0.0,0.0,0.0,0.0,0.0,0.0)</param>
-              <param name="r_arm_ft_sensor">(0.0,0.0,0.0,0.0,0.0,0.0,0.0)</param>
+              <param name="l_arm_ft">(0.0,0.0,0.0,0.0,0.0,0.0,0.0)</param>
+              <param name="r_arm_ft">(0.0,0.0,0.0,0.0,0.0,0.0,0.0)</param>
        </group>
   ```
 
@@ -143,8 +143,8 @@ Typically this estimates are provided only for the upper joints (arms and torso)
   Example of part of a configuration file using `.xml` `yarprobotinterface` format (remember to put the fractional dot!).
   ``` xml
        <group name="FT_OFFSET">
-              <param name="l_arm_ft_sensor">(0.0,0.0,0.0,0.0,0.0,0.0)</param>
-              <param name="r_arm_ft_sensor">(0.0,0.0,0.0,0.0,0.0,0.0)</param>
+              <param name="l_arm_ft">(0.0,0.0,0.0,0.0,0.0,0.0)</param>
+              <param name="r_arm_ft">(0.0,0.0,0.0,0.0,0.0,0.0)</param>
        </group>
   ```
 
@@ -215,12 +215,12 @@ For a detailed explanation on their usage, please see the document [Using temper
                   <!-- imu -->
                   <elem name="imu">inertial</elem>
                   <!-- ft -->
-                  <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                  <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                  <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                  <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                  <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                  <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                  <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                  <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                  <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                  <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                  <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                  <elem name="r_foot_ft">right_lower_leg_strain</elem>
               </paramlist>
           </action>
 

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-four-fts.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-four-fts.xml
@@ -101,22 +101,22 @@
     <!-- six axis force torque sensors -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_arm_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft </param>
     </device>
 
     <!-- estimators -->

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts-sim.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts-sim.xml
@@ -65,32 +65,32 @@
     <!-- six axis force torque sensors -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_arm_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft </param>
     </device>
 
     <device name="left_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_ft </param>
     </device>
 
     <device name="right_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_ft </param>
     </device>
 
     <!-- estimators -->

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts.xml
@@ -101,32 +101,32 @@
     <!-- six axis force torque sensors -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_arm_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft </param>
     </device>
 
     <device name="left_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_ft </param>
     </device>
 
     <device name="right_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_ft </param>
     </device>
 
     <!-- estimators -->

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub3-sim.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub3-sim.xml
@@ -42,42 +42,42 @@
     <!-- six axis force torque sensors -->
     <device name="left_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_arm_ft </param>
     </device>
 
     <device name="right_upper_arm_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_arm/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_arm_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_arm_ft </param>
     </device>
 
     <device name="left_lower_leg_front_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_foot_front/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_foot_front_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_front_ft </param>
     </device>
 
     <device name="left_lower_leg_rear_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_foot_rear/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_foot_rear_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_rear_ft </param>
     </device>
 
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/left_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft </param>
     </device>
 
     <device name="right_lower_leg_front_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_foot_front/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_foot_front_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_front_ft </param>
     </device>
 
     <device name="right_lower_leg_rear_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_foot_rear/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_foot_rear_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_rear_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icubSim/right_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft </param>
     </device>
 
     <!-- estimators -->

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icubheidelberg01.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icubheidelberg01.xml
@@ -49,22 +49,22 @@
     <!-- six axis force torque sensors -->
     <device name="left_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_leg_ft </param>
     </device>
 
     <device name="right_upper_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_leg/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_leg_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_leg_ft </param>
     </device>
 
     <device name="left_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/left_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/l_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/l_foot_ft </param>
     </device>
 
     <device name="right_lower_leg_strain" type="analogsensorclient">
         <param name="remote"> /icub/right_foot/analog:o </param>
-        <param name="local"> /wholeBodyDynamics/r_foot_ft_sensor </param>
+        <param name="local"> /wholeBodyDynamics/r_foot_ft </param>
     </device>
 
     <!-- estimators -->

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub-eth-six-fts.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub-eth-six-fts.xml
@@ -109,12 +109,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-four-fts.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-four-fts.xml
@@ -111,10 +111,10 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-six-fts.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-six-fts.xml
@@ -111,12 +111,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-six-fts-sim.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-six-fts-sim.xml
@@ -116,12 +116,12 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icub3-external-sim.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icub3-external-sim.xml
@@ -98,14 +98,14 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_arm_ft_sensor">left_upper_arm_strain</elem>
-                <elem name="r_arm_ft_sensor">right_upper_arm_strain</elem>
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="l_foot_front_ft_sensor">left_lower_leg_front_strain</elem>
-                <elem name="l_foot_rear_ft_sensor">left_lower_leg_rear_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="r_foot_front_ft_sensor">right_lower_leg_front_strain</elem>
-                <elem name="r_foot_rear_ft_sensor">right_lower_leg_rear_strain</elem>
+                <elem name="l_arm_ft">left_upper_arm_strain</elem>
+                <elem name="r_arm_ft">right_upper_arm_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="l_foot_front_ft">left_lower_leg_front_strain</elem>
+                <elem name="l_foot_rear_ft">left_lower_leg_rear_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="r_foot_front_ft">right_lower_leg_front_strain</elem>
+                <elem name="r_foot_rear_ft">right_lower_leg_rear_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-external.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-external.xml
@@ -79,10 +79,10 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-robot.xml
+++ b/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-robot.xml
@@ -75,10 +75,10 @@
                 <!-- imu -->
                 <elem name="imu">inertial</elem>
                 <!-- ft -->
-                <elem name="l_leg_ft_sensor">left_upper_leg_strain</elem>
-                <elem name="r_leg_ft_sensor">right_upper_leg_strain</elem>
-                <elem name="l_foot_ft_sensor">left_lower_leg_strain</elem>
-                <elem name="r_foot_ft_sensor">right_lower_leg_strain</elem>
+                <elem name="l_leg_ft">left_upper_leg_strain</elem>
+                <elem name="r_leg_ft">right_upper_leg_strain</elem>
+                <elem name="l_foot_ft">left_lower_leg_strain</elem>
+                <elem name="r_foot_ft">right_lower_leg_strain</elem>
             </paramlist>
         </action>
 

--- a/doc/howto/useTemperatureCoefficientsAndOffsetCompensationInWholeBodyDynamics.md
+++ b/doc/howto/useTemperatureCoefficientsAndOffsetCompensationInWholeBodyDynamics.md
@@ -16,8 +16,8 @@ To enable the use of temperature compensation and constant offset features in wh
 Example: 
 ```
 <group name="multipleAnalogSensorsNames">
-              <param name="TemperatureSensorsNames">(l_leg_ft_sensor,r_leg_ft_sensor,l_foot_ft_sensor,r_foot_ft_sensor)</param>
-              <param name="SixAxisForceTorqueSensorsNames">(l_leg_ft_sensor,r_leg_ft_sensor,l_foot_ft_sensor,r_foot_ft_sensor)</param>
+              <param name="TemperatureSensorsNames">(l_leg_ft,r_leg_ft,l_foot_ft,r_foot_ft)</param>
+              <param name="SixAxisForceTorqueSensorsNames">(l_leg_ft,r_leg_ft,l_foot_ft,r_foot_ft)</param>
 </group>`
 ```
 ## Add the temperature coefficients
@@ -28,7 +28,7 @@ Example:
 
 ```
        <group name="FT_TEMPERATURE_COEFFICIENTS">
-              <param name="l_leg_ft_sensor">(-0.0933  ,  0.2048  ,  1.3342  , -0.0155  ,  0.0027  ,  0.0039  , 30.4064)</param>
+              <param name="l_leg_ft">(-0.0933  ,  0.2048  ,  1.3342  , -0.0155  ,  0.0027  ,  0.0039  , 30.4064)</param>
         </group>
 ```
 
@@ -39,8 +39,8 @@ Inside the group the name of the sensors followed by its coefficients should be 
 Example:
 ```
         <group name="FT_OFFSET">
-              <param name="l_leg_ft_sensor">(24.8009  , -6.2369 , -62.0044 , -0.0588 ,  -0.2425  ,  0.1253)</param>
-             <!-- <param name="r_leg_ft_sensor">(0.0,0.0,0.0,0.0,0.0,0.0)</param> -->
+              <param name="l_leg_ft">(24.8009  , -6.2369 , -62.0044 , -0.0588 ,  -0.2425  ,  0.1253)</param>
+             <!-- <param name="r_leg_ft">(0.0,0.0,0.0,0.0,0.0,0.0)</param> -->
        </group>
 ```
 


### PR DESCRIPTION
Revised version of https://github.com/robotology/whole-body-estimators/pull/171 after reviews from @HosameldinMohamed .

Fix https://github.com/robotology/icub-models-generator/issues/242 .

icub-models 2.0.0 changed the name of the FT sensors in the URDF from being named `<identifier>_ft_sensor` (like `l_arm_ft_sensor`, `l_leg_ft_sensor`, ...) to `<identifier>_ft` (like `l_arm_ft`, `l_leg_ft`, ...). 
However, the yarprobotinterface configuration files continued to refer to the sensors as `<identifier>_ft_sensor`, creating errors for software that was trying to match sensors find in URDF and sensors as exposed by the YARP's multipleanalogsensorsserver device.

This PR changes all the instances of iCub configuration files to `<identifier>_ft`, restoring compatibility with icub-models 2.0.0, robots-configuration releases >= 2.5.0 and ergocub-software >= 0.3.4, see https://github.com/robotology/robots-configuration/pull/562 .


Note that the name of the joint to which the sensor is attached remained `<identifier>_ft_sensor`, both before and after icub-models 2.0.0 release.