### PR TITLE
Fix WBD config files broken in #173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix WBD config files broken in #173 (https://github.com/robotology/whole-body-estimators/pull/175).
 
 ## [0.10.0] - 2023-09-11
 

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-four-fts.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-four-fts.xml
@@ -120,5 +120,5 @@
     </device>
 
     <!-- estimators -->
-    <xi:include href="./wholebodydynamics-icub-external-and-can-four-fts.xml" />
+    <xi:include href="estimators/wholebodydynamics-external.xml" />
 </robot>

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts-sim.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts-sim.xml
@@ -84,5 +84,5 @@
     </device>
 
     <!-- estimators -->
-    <xi:include href="./wholebodydynamics-icub-external-six-fts-sim.xml" />
+    <xi:include href="estimators/wholebodydynamics-external.xml" />
 </robot>

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub-six-fts.xml
@@ -130,5 +130,5 @@
     </device>
 
     <!-- estimators -->
-    <xi:include href="./wholebodydynamics-icub-external-and-can-six-fts.xml" />
+    <xi:include href="estimators/wholebodydynamics-external.xml" />
 </robot>

--- a/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub3-sim.xml
+++ b/devices/wholeBodyDynamics/app/launch-wholebodydynamics-icub3-sim.xml
@@ -61,5 +61,5 @@
     </device>
 
     <!-- estimators -->
-    <xi:include href="./wholebodydynamics-icub3-external-sim.xml" />
+    <xi:include href="estimators/wholebodydynamics-external.xml" />
 </robot>


### PR DESCRIPTION
I changed the way the config files are called in #173, where I hard-coded the name of the estimator XML file to be called by the launch file. For example `launch-wholebodydynamics-icub-six-fts-sim.xml` calls `wholebodydynamics-icub-external-six-fts-sim.xml`.

But looking at the CMake code, the launch files are installed with the generic name `launch-wholebodydynamics.xml`, and the estimator files are installed as `estimators/wholebodydynamics.xml`, and it's installed for the following real robots `iCubDarmstadt01;iCubGenova02;iCubGenova04;iCubNancy01`, and for the simulated robots: `icubGazeboSim`, `iCubGazeboV2_5`, and `iCubGazeboV3`.

So I reverted to the correct line in this PR.