### PR TITLE
Add periodic action to update pixi lock file

### DIFF
--- a/.github/workflows/pixi-auto-update-ci.yml
+++ b/.github/workflows/pixi-auto-update-ci.yml
@@ -1,0 +1,31 @@
+name: Pixi auto update
+
+on:
+  # At 00:00 of every monday
+  schedule:
+    - cron: "0 0 * * 1*"
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.5.1
+        with:
+          pixi-version: "latest"
+          cache: false
+      - name: Update pixi lock file
+        run: |
+          rm pixi.lock
+          pixi install
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pixi-lock
+          title: Update pixi lock file
+          commit-message: "Update `pixi.lock`"
+          body: Update pixi dependencies to the latest version.
+          author: "GitHub <noreply@github.com>"


### PR DESCRIPTION
I am mostly playing with pixi here. The idea of this is described in https://github.com/prefix-dev/setup-pixi/issues/82. 

TL;DR: Every once in a while we want to update the pixi lock file, to ensure that the software does not stop working with new versions of the dependencies, while ensuring that the PRs continue to work with fixed versions of the dependencies.