### PR TITLE
Stop using CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## Unreleased
-### Added
-
-### Changed
-
-### Fixed
-- Fix WBD config files broken in #173 (https://github.com/robotology/whole-body-estimators/pull/175).
+This file documents notable changes to this project done before September 2023. For changes after that date, plase refers to the release notes of each release at https://github.com/robotology/robotology-superbuild/releases .
 
 ## [0.10.0] - 2023-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This file documents notable changes to this project done before September 2023. For changes after that date, plase refers to the release notes of each release at https://github.com/robotology/robotology-superbuild/releases .
+This file documents notable changes to this project done before September 2023. For changes after that date, plase refers to the release notes of each release at https://github.com/robotology/whole-body-estimators/releases .
 
 ## [0.10.0] - 2023-09-11
 


### PR DESCRIPTION
From a project of this size, I this is is perfectly fine to write good PR messages, and the automatically generate the release notes using GitHub functionality, without the need to manually maintain a `CHANGELOG.md` file.

This simplifies the process of making releases.