### PR TITLE
Remove scheduled pixi auto-update and add scheduled build with latest dependencies

### DIFF
--- a/.github/workflows/pixi-auto-update-ci.yml
+++ b/.github/workflows/pixi-auto-update-ci.yml
@@ -1,9 +1,6 @@
 name: Pixi auto update
 
 on:
-  # At 00:00 of every monday
-  schedule:
-    - cron: "0 0 * * 1"
   # on demand
   workflow_dispatch:
 

--- a/.github/workflows/pixi-ci.yml
+++ b/.github/workflows/pixi-ci.yml
@@ -1,7 +1,18 @@
 name: CI Workflow
 
 on:
+  # on demand
+  workflow_dispatch:
+    inputs:
+      delete_pixi_lock:
+        description: 'If true, delete pixi.lock, to test against the latest version of dependencies.'
+        required: true
+        default: 'false'
   pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build twice a week 2 AM UTC
+  - cron:  '0 2 * * 2,5'
 
 jobs:
   build-with-pixi:
@@ -15,6 +26,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    # On periodic jobs and when delete_pixi_lock option is true, delete the pixi.lock to check that the project compiles with latest version of dependencies
+    - name: Delete pixi.lock on scheduled jobs or if delete_pixi_lock is true
+      if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.delete_pixi_lock == 'true')
+      shell: bash
+      run: |
+        rm -rf pixi.lock
+        pixi list
+        cat pixi.lock
 
     - name: Print used environment
       shell: bash

--- a/.github/workflows/pixi-ci.yml
+++ b/.github/workflows/pixi-ci.yml
@@ -32,9 +32,7 @@ jobs:
       if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.delete_pixi_lock == 'true')
       shell: bash
       run: |
-        rm -rf pixi.lock
-        pixi list
-        cat pixi.lock
+        rm pixi.lock
 
     - name: Print used environment
       shell: bash


### PR DESCRIPTION
This is a bit of iteration on https://github.com/robotology/whole-body-estimators/pull/178 and what is described in https://github.com/prefix-dev/pixi/discussions/910 . 

The idea of https://github.com/robotology/whole-body-estimators/pull/178 is that once in a while we wanted to update the pixi lock file, to ensure that the software does not stop working with new versions of the dependencies. However, periodic update of the pixi lock file have the downside that the repo size continue to grow, even if the repo is not changed at all. Furthermore, the PR for the update for the lock needs to be manually merged, and they add noise in the PRs for the repo.

After a bit of experience with the solution added in https://github.com/robotology/whole-body-estimators/pull/178, I thought of another solution: added a scheduled job that deletes the `pixi.lock` and run the CI on a freshly created `pixi.lock`, to test the compilation and tests with the latest version of the dependencies (as we used to do with the `conda-ci`). In this way, we frequently test the latest versions, without changing the `pixi.lock`, unless necessary. Note that I left the `pixi-auto-update-ci` action, as it can be useful to update the `pixi.lock` via `workflow_dispatch` via the GitHub Actions. The frequency of the scheduled job is bi-weekly.

