### PR TITLE
WholeBodyDynamicsDevice: Remove meaningless check that total number FTs in attached device match the total number of FTs consired by estimation

### DIFF
--- a/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -1822,18 +1822,6 @@ bool WholeBodyDynamicsDevice::attachAllFTs(const PolyDriverList& p)
         return false;
     }
 
-    if (nrMASFTSensors != remappedMASInterfaces.ftMultiSensors->getNrOfSixAxisForceTorqueSensors())
-    {
-        yError() << "WholeBodyDynamicsDevice::attachAll Invalid number of MAS FT sensors after remapper";
-        return false;
-    }
-
-    if (nrMASFTSensors != ftMultipleAnalogSensorNames.size())
-    {
-	yError() << "WholeBodyDynamicsDevice::attachAll Invalid number of MAS FT sensor names";
-        return false;
-    }
-
     ftMultipleAnalogSensorIdxMapping.resize(ftMultipleAnalogSensorNames.size());
     for (auto ftDx = 0; ftDx < nrMASFTSensors; ftDx++)
     {


### PR DESCRIPTION
This is a bug found by @LoreMoretti , basically he was trying to remote just the upper_leg FTs from ergocub from the estimation, but the wbd launch was failing with:

~~~
        yError() << "WholeBodyDynamicsDevice::attachAll Invalid number of MAS FT sensors after remapper";
~~~

However, the check does not make a lot of sense. `nrMASFTSensors` is the total number of FT sensors in all the devices attached to wbd (for ergocub 8), while ` remappedMASInterfaces.ftMultiSensors->getNrOfSixAxisForceTorqueSensors()` and `ftMultipleAnalogSensorNames.size()` are the actual number of sensors considered (removing the `upper_leg` fts as @LoreMoretti was doing, 6).

To be honest, I am wondering how we were removing the FT from the estimation with this bug. Perhaps in all other cases were also either avoiding to pass the upper_leg FTs devices to the attach list, or we removed the FT sensors from the devices opened by the yarprobotinterface?