### PR TITLE
Migrate pixi-ci to windows-latest

### DIFF
--- a/.github/workflows/pixi-ci.yml
+++ b/.github/workflows/pixi-ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       run: |
         env
 
-    - uses: prefix-dev/setup-pixi@v0.5.1
+    - uses: prefix-dev/setup-pixi@v0.8.8
 
     - name: Run the tests
       shell: bash -l {0}


### PR DESCRIPTION
Related issue: https://github.com/robotology/robotology-superbuild/issues/1858 .